### PR TITLE
Added bridging functionallity to PHP.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ documentation = "https://nsoiffer.github.io/MathCAT/"
 edition = "2018"
 exclude = ["src/main.rs", "docs", "PythonScripts"]    # should have "Rules/", but then one can't run build.rs to build the zip file
 
-
 [features]
 "include-zip" = []
 "enable-logs" = ["android_logger"]
@@ -38,6 +37,7 @@ log = "0.4"
 env_logger = "0.11.8"
 cfg-if = "1.0.1"
 fastrand = { version = "2.3.0" }
+ext-php-rs = "0.10.0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 zip = { version = "4.3", default-features = false, features = ["deflate"] }
@@ -47,7 +47,6 @@ zip = { version = "4.3", default-features = false, features = ["bzip2"] }
 android_logger = {version = "0.15.1", optional = true}
 
 
-
 [build-dependencies]
 bitflags = "2.6"
 error-chain = "0.12.4"
@@ -55,9 +54,10 @@ error-chain = "0.12.4"
 zip = { version = "4.3", default-features = false, features = ["deflate"] }
 [target.'cfg(not(target_family = "wasm"))'.build-dependencies]
 zip = { version = "4.3", default-features = false, features = ["bzip2"] }
+bindgen = "0.64.0"
 
 [lib]
-name = "libmathcat"
+name = "mathcat"
 crate-type = ["rlib", "cdylib"]
 
 [profile.test]

--- a/src/chemistry.rs
+++ b/src/chemistry.rs
@@ -606,18 +606,7 @@ fn is_changed_after_unmarking_chemistry(mathml: Element) -> bool {
     } else {
         let mut answer = false;
         for child in mathml.children() {
-            let child = as_element(child);
-            if name(child) == "mtd" {
-                assert_eq!(child.children().len(), 1);
-                // let mtd_child = as_element(child.children()[0]);
-                // if mtd_child.attribute(CHEM_FORMULA).is_none() && mtd_child.attribute(CHEM_EQUATION).is_none() {
-                // } else {
-
-                // }
-                answer = true;
-            } else {
-                answer |= is_changed_after_unmarking_chemistry(child);
-            }
+            answer |= is_changed_after_unmarking_chemistry(as_element(child));
         }
         if name(mathml) == "mrow" {
             if let Some(changed_value) = mathml.attribute_value(CHANGED_ATTR) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,7 @@ mod chemistry;
 
 pub mod shim_filesystem; // really just for override_file_for_debugging_rules, but the config seems to throw it off
 pub use interface::*;
+pub use ext_php_rs::prelude::*;
 
 #[cfg(test)]
 pub fn init_logger() {
@@ -122,5 +123,30 @@ pub fn are_strs_canonically_equal_with_locale(test: &str, target: &str, block_se
 // sets locale to be US standard
 pub fn are_strs_canonically_equal(test: &str, target: &str) -> bool {
     return are_strs_canonically_equal_with_locale(test, target, ", \u{00A0}\u{202F}", ".");
+}
+
+#[php_function]
+pub fn mathcat_set_rules_dir(dir: String) {
+    let _ = set_rules_dir(dir);
+}
+
+#[php_function]
+pub fn mathcat_set_mathml(mathml_str: String) -> String {
+    return set_mathml(mathml_str).unwrap();
+}
+
+#[php_function]
+pub fn mathcat_get_spoken_text() -> String {
+    return get_spoken_text().unwrap();
+}
+
+#[php_function]
+pub fn mathcat_set_preference(name: String, value: String) {
+    let _ = set_preference(name, value);
+}
+
+#[php_module]
+pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
+    module
 }
 


### PR DESCRIPTION
This PR will add a couple of functions to the code so you can add this library as a PHP module and run it directly from the PHP code. I've seen that other glue codes have separate repositories, so this might not be how to implement this. I am still very early in my Rust journey, so I've not looked into multi-repository solutions.

I also did a small bug fix so the library doesn't have the name `liblibmathcat.so`

Best regards
Daniel