### PR TITLE
Fix assertions in chemistry.rs that could never fail (#551)

### DIFF
--- a/src/chemistry.rs
+++ b/src/chemistry.rs
@@ -1282,7 +1282,7 @@ fn has_c_h_o(elements: &[NameStr<'_>]) -> bool {
 
 
 fn is_structural(elements: &[NameStr<'_>]) -> bool {
-    assert!(!elements.len() > 1);   // already handled
+    assert!(elements.len() > 1);   // already handled
 
     // debug!("is_structural: {:?}", elements);
     let mut element_set = HashSet::with_capacity(elements.len());
@@ -1318,7 +1318,7 @@ fn collect_elements(mrow: Element<'_>) -> Option<Vec<NameStr<'_>>> {
 #[allow(clippy::op_ref)]
 #[allow(clippy::manual_contains)]
 fn is_alphabetical(elements: &[NameStr<'_>]) -> bool {
-    assert!(!elements.len() > 1);   // already handled
+    assert!(elements.len() > 1);   // already handled
     // debug!("is_alphabetical: {:?}", elements);
     let mut elements = elements;
     if elements[1..].iter().any(|e| *e == "C") {  // "C" must be first if present
@@ -1333,7 +1333,7 @@ fn is_alphabetical(elements: &[NameStr<'_>]) -> bool {
 fn is_ordered_by_electronegativity(elements: &[NameStr<'_>]) -> bool {
     // HPO_4^2 (Mono-hydrogen phosphate) doesn't fit this pattern, nor does HCO_3^- (Hydrogen carbonate) and some others
     // FIX: drop "H" from the ordering??
-    assert!(!elements.len() > 1);   // already handled
+    assert!(elements.len() > 1);   // already handled
     return elements.windows(2).all(|pair| CHEMICAL_ELEMENT_ELECTRONEGATIVITY.get(as_str!(pair[0])).unwrap() < CHEMICAL_ELEMENT_ELECTRONEGATIVITY.get(as_str!(pair[1])).unwrap());
 }
 


### PR DESCRIPTION
Fixes #551.

## The defect

`assert!(!elements.len() > 1)` parses as `(!elements.len()) > 1`. `len()` returns `usize`, so `!` is a bitwise complement rather than a logical negation — `!0` is `usize::MAX` and `!1` is `usize::MAX - 1`, both greater than 1. The assertion held for every possible input and checked nothing.

Three sites, all carrying the same `// already handled` comment: `is_structural`, `is_alphabetical` and `is_ordered_by_electronegativity`.

## Why `elements.len() > 1` is the intended condition

Read off the bodies rather than inferred from the comment alone:

- `is_alphabetical` indexes `elements[0]` and `elements[1]`, so fewer than two elements would panic on the index itself.
- `is_ordered_by_electronegativity` is `elements.windows(2).all(...)`, which vacuously returns `true` for a slice shorter than 2 — a meaningless answer rather than a crash.
- `is_structural` compares a de-duplicated set size against `elements.len()`, which can only differ once there are at least two.

## Why the corrected assertion does not start firing

The `// already handled` comment refers to the sole caller, `is_order_ok`:

```rust
let n_elements = elements.len();
if n_elements < 2 {
    return true;
} else if has_noble_element(&elements) {
    return false;
} else {
    return ... is_structural(&elements) || is_alphabetical(&elements) || ...
```

so the three functions are unreachable with fewer than two elements. The unit tests call them directly, and every input in `test_is_alphabetical`, `test_is_structural` and `test_electronegativity_order` has two or more elements (C+H, C+H+O, B+C+O, P+B+O, H+O+H, H+C+C+H, N+H, O+F).

## Left alone deliberately

Two nearby assertions also begin with `!`, but there the operand is a `bool` and the negation is correct, so they are untouched: `assert!(!script_children.len().is_multiple_of(2))` and `assert!(!elements.is_empty())`. The patch was applied by a script that asserted both survive unchanged, so this is checked rather than claimed.

## Verification

Run on a fork at this commit — all jobs green: `Build and Test (default)`, `Build and Test (no-unsafe)`, `Clippy/Lint check (default)`, `Clippy/Lint check (no-unsafe)`, and the rules-zip job. Note the workflow sets `RUSTFLAGS: -Dwarnings`, so the corrected expression introduces no new warning.

Per AGENTS.md I kept the change focused and did not run `cargo fmt`; the diff is three characters removed.