### PR TITLE
simplify TTS using strum

### DIFF
--- a/src/navigate.rs
+++ b/src/navigate.rs
@@ -13,6 +13,7 @@ use crate::pretty_print::mml_to_string;
 use crate::speech::{NAVIGATION_RULES, CONCAT_INDICATOR, CONCAT_STRING, SpeechRules, SpeechRulesWithContext};
 use crate::infer_intent::add_fixity_children;
 use crate::interface::copy_mathml;
+use crate::tts::TTS;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
 use crate::errors::*;
@@ -405,15 +406,15 @@ pub fn do_navigate_command_string(mathml: Element, nav_command: &'static str) ->
                         if done {
                             let (tts, rate) = {
                                 let prefs = rules.pref_manager.borrow();
-                                (prefs.pref_to_string("TTS"), prefs.pref_to_string("MathRate"))
+                                (prefs.get_tts(), prefs.pref_to_string("MathRate"))
                             };
                             if rate != "100" {
-                                match tts.as_str() {
-                                    "SSML"
+                                match tts {
+                                    TTS::SSML
                                         if !cumulative_speech.starts_with("<prosody rate") => {
                                             cumulative_speech = format!("<prosody rate='{}%'>{}</prosody>", rate, cumulative_speech);
                                         }
-                                    "SAPI5"
+                                    TTS::SAPI5
                                         if !cumulative_speech.starts_with("<rate speed") => {
                                             cumulative_speech = format!(
                                                 "<rate speed='{:.1}'>{}</rate>",

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -727,15 +727,11 @@ impl PreferenceManager {
             panic!("Internal error: get_tts called on invalid PreferenceManager -- error message\n{}", self.error);
         };
 
-        return match self.pref_to_string("TTS").as_str().to_ascii_lowercase().as_str() {
-            "none" => TTS::None,
-            "ssml" => TTS::SSML,
-            "sapi5" => TTS::SAPI5,
-            _ => {
-                warn!("found unknown value for TTS: '{}'", self.pref_to_string("TTS").as_str());
-                TTS::None
-            }
-        }
+        let tts: String = self.pref_to_string("TTS");
+        return tts.parse().unwrap_or_else(|_| {
+            warn!("found unknown value for TTS: '{tts}'");
+            TTS::None
+        })
     }
 
     /// Set the string-valued preference.

--- a/src/tts.rs
+++ b/src/tts.rs
@@ -257,7 +257,8 @@ impl TTSCommandRule {
 /// These types should do something for all the TTSCommands
 #[allow(clippy::upper_case_acronyms)]
 #[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Display, EnumString)]
+#[strum(ascii_case_insensitive)]
 pub enum TTS {
     None,
     SSML,
@@ -766,6 +767,13 @@ impl TTS {
 mod tests {
     use super::*;
     use yaml_rust::YamlLoader;
+
+    #[test]
+    fn tts_display_and_case_insensitive_parse() {
+        assert_eq!(TTS::SSML.to_string(), "SSML");
+        assert_eq!("sapi5".parse::<TTS>(), Ok(TTS::SAPI5));
+        assert_eq!("NoNe".parse::<TTS>(), Ok(TTS::None));
+    }
 
     #[test]
     /// Verifies pronounce YAML builds and renders all supported fields.


### PR DESCRIPTION
this is another case I found.
generally, I prefer to use actual enum instances instead of strings, so that's cleaner imo,
and additionally, it remove duplicated logic from prefs.rs