### PR TITLE
Remove unused `error` field and error handling logic from `SpeechRules`.

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -364,13 +364,6 @@ fn set_preference_impl(name: &str, value: &str) -> Result<()> {
         }
     }
 
-    crate::speech::SPEECH_RULES.with(|rules| -> Result<()> {
-        if let Some(error_string) = rules.borrow().get_error() {
-            bail!("{}", error_string);
-        }
-        Ok(())
-    })?;
-
     // Do not hold a SpeechRules borrow while updating preferences: invalidation clears rule caches.
     let pref_manager = crate::prefs::PreferenceManager::get();
     let mut pref_manager = pref_manager.borrow_mut();

--- a/src/speech.rs
+++ b/src/speech.rs
@@ -2101,11 +2101,7 @@ impl FilesAndTimes {
 
 /// `SpeechRulesWithContext` encapsulates a named group of speech rules (e.g, "ClearSpeak")
 /// along with the preferences to be used for speech.
-// Note: if we can't read the files, an error message is stored in the structure and needs to be checked.
-// I tried using Result<SpeechRules>, but it was a mess with all the unwrapping.
-// Important: the code needs to be careful to check this at the top level calls
 pub struct SpeechRules {
-    error: String,
     name: RulesFor,
     pub pref_manager: Rc<RefCell<PreferenceManager>>,
     rules: RuleTable,                              // the speech rules used (partitioned into MathML tags in hashmap, then linearly searched)
@@ -2267,7 +2263,6 @@ impl SpeechRules {
         };
 
         return SpeechRules {
-            error: Default::default(),
             name,
             rules: HashMap::with_capacity(if name == RulesFor::Intent || name == RulesFor::Speech {500} else {50}),                       // lazy load them
             rule_files: FilesAndTimes::default(),
@@ -2280,14 +2275,6 @@ impl SpeechRules {
             pref_manager: PreferenceManager::get(),
         };
 }
-
-    pub fn get_error(&self) -> Option<&str> {
-        return if self.error.is_empty() {
-             None
-        } else {
-            Some(&self.error)
-        }
-    }
 
     pub fn read_files(&mut self) -> Result<()> {
         let check_rule_files = self.pref_manager.borrow().pref_to_string("CheckRuleFiles");


### PR DESCRIPTION
similar to the preference manager, the error is never actually set. `cargo test` still passes nicely.