### PR TITLE
Refactor `strum` dependency to use `derive` feature and replace `strum_macros` imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ sxd-document-no-unsafe = "0.4.2"
 sxd-xpath-no-unsafe = "0.5.1"
 yaml-rust = "0.4"
 # yaml-rust = { version = "0.11", package = "yaml-rust2" }
-strum = "0.28"
-strum_macros = "0.28"
+strum = { version = "0.28", features = ["derive"] }
 anyhow = "1.0"
 regex = "1.12.3"
 dirs = "6.0"

--- a/src/braille.rs
+++ b/src/braille.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::needless_return)]
-use strum_macros::Display;
+use strum::Display;
 use sxd_document_no_unsafe::dom::{Element, ChildOfElement};
 use sxd_document_no_unsafe::Package;
 use sxd_document_no_unsafe::as_str;

--- a/src/speech.rs
+++ b/src/speech.rs
@@ -16,7 +16,7 @@ use sxd_xpath_no_unsafe::{Factory, Value, XPath};
 use sxd_xpath_no_unsafe::nodeset::Node;
 use std::fmt;
 use std::time::SystemTime;
-use strum_macros::Display;
+use strum::Display;
 use crate::definitions::read_definitions_file;
 use crate::errors::*;
 use crate::prefs::*;

--- a/src/tts.rs
+++ b/src/tts.rs
@@ -75,7 +75,7 @@ use std::fmt;
 use crate::speech::{RulesFor, SpeechRulesWithContext, MyXPath, TreeOrString};
 use std::string::ToString;
 use std::str::FromStr;
-use strum_macros::{Display, EnumString};
+use strum::{Display, EnumString};
 use regex::Regex;
 use std::sync::LazyLock;
 use sxd_xpath_no_unsafe::Value;


### PR DESCRIPTION
https://docs.rs/strum/latest/strum/index.html#derives


minor cleanup of cargo.toml