### PR TITLE
Recognize lg as an ASCIIMath function

### DIFF
--- a/Rules/Braille/ASCIIMath/definitions.yaml
+++ b/Rules/Braille/ASCIIMath/definitions.yaml
@@ -11,7 +11,7 @@
     "lambda", "Lambda", "and", "or", "if",
     "lim", "Lim",
     "sin", "cos", "tan", "arcsin", "arccos", "arctan", "sinh", "cosh", "tanh", "cot", "coth", "sech", "csch", "sec", "csc",
-    "log", "ln", "abs", "norm", "floor", "ceil",
+    "log", "lg", "ln", "abs", "norm", "floor", "ceil",
     "Sin", "Cos", "Tan", "Arcsin", "Arccos", "Arctan", "Sinh", "Cosh", "Tanh", "Cot", "Sec", "Csc",
     "Log", "Ln", "det", "exp", "dim", "mod", "gcd", "lcm", "lub", "glb", "min", "max",
   }

--- a/tests/braille/ASCIIMath/augenbit.rs
+++ b/tests/braille/ASCIIMath/augenbit.rs
@@ -131,6 +131,14 @@ fn augenbit1_7_7 () -> Result<()> {
 }
 
 #[test]
+fn augenbit1_7_8 () -> Result<()> {
+    let expr = r#"<math><mi>lg</mi><mi>a</mi></math>"#;
+    test_braille("ASCIIMath", expr, r"lg a")?;
+    return Ok(());
+
+}
+
+#[test]
 fn augenbit1_7_10 () -> Result<()> {
     let expr = r#"<math><msup><mi>cos</mi><mn>2</mn></msup><mi>&#x3B2;</mi></math>"#;
     test_braille("ASCIIMath", expr, r"cos^2 beta")?;


### PR DESCRIPTION
Fixes #522

## Summary

Add `lg` to the ASCIIMath function-name list so it is spaced as a function rather than treated as a generic identifier. The change also adds an Augenbit regression test for `lg a`.

## Verification

- Before the rule change, the regression produced an unspaced identifier form instead of `lg a`.
- The full Braille suite passes with 1,694 tests passed, 35 ignored, and no failures.
- `uv run pytest` passes with 88 tests.