### PR TITLE
Add MathJax demo link to developer docs for rendering inspection

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -76,7 +76,7 @@ fn test_simple_fraction() {
 
 ## Helpful Links
 
-* [MathJax Demo](https://www.mathjax.org/#demo): lets you paste a MathML fragment and inspect its browser rendering.
+* [MathCAT Demo]([https://www.mathjax.org/#demo](https://daisy.github.io/MathCATDemo/)): lets you paste a MathML fragment and inspect its displayed math, speech and braille.
 
 ### Test Coverage
 

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -74,6 +74,10 @@ fn test_simple_fraction() {
 }
 ```
 
+## Helpful Links
+
+* [MathJax Demo](https://www.mathjax.org/#demo) (archived) lets you paste a MathML fragment and inspect its browser rendering. It can be useful when checking whether an input expression itself renders as expected.
+
 ### Test Coverage
 
 Test coverage helps identify which parts of the code are exercised by tests and which parts need more testing.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -76,7 +76,7 @@ fn test_simple_fraction() {
 
 ## Helpful Links
 
-* [MathJax Demo](https://www.mathjax.org/#demo) (archived) lets you paste a MathML fragment and inspect its browser rendering. It can be useful when checking whether an input expression itself renders as expected.
+* [MathJax Demo](https://www.mathjax.org/#demo): lets you paste a MathML fragment and inspect its browser rendering.
 
 ### Test Coverage
 


### PR DESCRIPTION
while working on some unit tests, I found the MathJax online demo to be quite helpful to quickly see the rendering of some MathML expressions. I think this may be worth linking for new devs.

@NSoiffer  the natural follow-up is: what other (non-obvious) tools are worth knowing, both for me and other new devs?