### PR TITLE
Critical important: fix a mistake after the yesterday doed selective merge with definitions.yaml and definitions.rs test file related

### DIFF
--- a/Rules/Languages/hu/definitions.yaml
+++ b/Rules/Languages/hu/definitions.yaml
@@ -87,14 +87,14 @@
     #"fraction":"function=fraction; over; end fraction", # NOTE: Fails
     "mixed-fraction":"infix=és", # NOTE: in website says function, but follow infix speech pattern.
     "greatest-common-divisor": "function=a legnagyobb közös osztó",
-    "quotient":"function=egész rész osztva", # NOTE: Logic somewhere here failing, becomes "divided by of x comma, y" instead of "integer part of x divided by y"
+    "quotient":"function=egész rész | osztva", # NOTE: Logic somewhere here failing, becomes "divided by of x comma, y" instead of "integer part of x divided by y"
     "evaluated-at":"infix=értékelve || postfix=értékként",
-    "remainder":"function=a maradék, osztva",
+    "remainder":"function=a maradék | osztva",
     "max":"function=max",
     "min":"function=min",
     "power":"infix=a hatványra",
     "root":"function=root",
-    "imaginary-part": "a képzeletbeli rész",
+    "imaginary-part": "function=a képzeletbeli rész: a képzeletbeli rész: a képzeletbeli rész",
     "least-common-multiple": "function=lcm: a legkisebb közös többszörös: a legkisebb közös többszörös",
     "complex-conjugate":"function=Komplex konjugált",
     "complex-arg":"function=argumentum",
@@ -131,15 +131,15 @@
     "tends-to-from-below":"infix=alulról indul",
     ### Sets
     "set": "function= ; halmaz: a halmaz",
-    "set-difference":"function=különbséghalmaz || infix=mínusz || postfix=különbséghalmaza", # NOTE: not tested
+    "set-difference":"function=különbséghalmaz | és || infix=mínusz",
     "complement":"function=komplemens",
-    "empty-set":"function=üres halmaz",
+    "empty-set":"nofix=üres halmaz",
     "cardinality":"function=számosság", # NOTE: does not have a defined speech template in website
     "list":"function=lista",
     "tuple": "function= ; tuple: a tuple",
     ### Sequence and Series
-    "sum":"function= ; összegzés : összeg ; ", #: sum over : sum from; to",
-    "product":"function=szorzat || function=szorzat vége || function=szorzat innen ide",
+    "sum": "function=összeg",
+    "product":"function=szorzat",
 
     ### Elementary classical functions
     "sine":"function=szinusz: szinusz",
@@ -225,6 +225,7 @@
     "highlight":"postfix=kiemelt",
     "least-common-denominator":"function=legkisebb közös nevező",
     "rate":"infix=per",
+    "translation":"function=fordítás",
     "constraint":"infix= ; feltétellel; ", 
 
     "binomial-coefficient":"infix=választ",

--- a/tests/Languages/hu/definitions.rs
+++ b/tests/Languages/hu/definitions.rs
@@ -32,7 +32,7 @@ fn my_set_basic() -> Result<()> {
       </math>
     "#;
 
-    test("hu", "ClearSpeak", expr, "az üres halmaz")?;
+    test("hu", "ClearSpeak", expr, "a halmaz x vessző, y")?;
 
     Ok(())
 }
@@ -91,7 +91,7 @@ fn set_difference_basic() -> Result<()> {
       </math>
     "#;
 
-    test( "hu", "ClearSpeak", expr, "különbséghalmaz nagy a vessző, nagy b")?;
+    test( "hu", "ClearSpeak", expr, "különbséghalmaz nagy a és nagy b")?;
 
     Ok(())
 }
@@ -107,7 +107,7 @@ fn postfix_test() -> Result<()> {
                 <mo>T</mo>
             </msup>
             "#,
-            "transzponált x",
+            "x transzponált",
         ),
         (
             "highlight",
@@ -205,9 +205,9 @@ fn functions_and_inverses_tests() -> Result<()> {
 
         //("fraction", "fraction x over y end fraction"),
         ("mixed-fraction", "x és y"),
-        ("quotient", "egész rész osztva x vessző, y"),
+        ("quotient", "egész rész x osztva y"),
         ("evaluated-at", "x értékelve y"),
-        ("remainder", "a maradék, osztva x vessző, y"),
+        ("remainder", "a maradék x osztva y"),
 
         ("max", "max x vessző, y vessző, z"),
         ("min", "min x vessző, y vessző, z"),
@@ -223,13 +223,13 @@ fn functions_and_inverses_tests() -> Result<()> {
 
         ("complex-conjugate", "Komplex konjugált x"),
         ("complex-arg", "argumentum x"),
-        ("real-part", "valós rész"),
-        ("imaginary-part", "képzetes rész"),
+        ("real-part", "az igazi rész x"),
+        ("imaginary-part", "a képzeletbeli rész x"),
 
         ("polar-coordinate", "poláris koordináta x vessző, y"),
         ("spherical-coordinate", "gömb koordináta x vessző, y vessző, z"),
         ("cartesian-coordinate", "derékszögű koordináta x vessző, y vessző, z"),
-        ("coordinate", "pont, x vessző y vessző z"),
+        ("coordinate", "koordináta x vessző, y vessző, z"),
 
         ("floor", "lépcső x"),
         ("ceiling", "mennyezet x"),
@@ -528,7 +528,7 @@ fn statistics_and_probability_tests() -> Result<()> {
         ("mode", "mód x"),
 
         // conditional probability typically two arguments
-        // ("conditional-probability", "probability of x given y"),
+        // ("conditional-probability", "valószínűség x adott y"),
     ];
 
     for (intent, expected) in tests {
@@ -576,7 +576,7 @@ fn linear_algebra_tests() -> Result<()> {
         ("span", "fesztávolság x"),
 
         // transpose supports both postfix and function; we test function explicitly
-        ("transpose", "transzponált x"),
+        ("transpose", "x transzponált"),
 
         // dimensional product is infix
         ("dimensional-product", "x a(z) y"),
@@ -727,13 +727,13 @@ fn general_concepts_tests() -> Result<()> {
         ("permutation-cycle", "permutációs ciklus x"),
 
         // Binary structural / infix-style
-        // ("ordered-pair", "the pair of x and y"),
+        ("ordered-pair", "a pár x és y"),
         ("rate", "x per y"),
         
         ("binomial-coefficient", "x választ y"),
         ("embellished-name", "x megjegyzéssel y"),
         ("indexed-by", "x alsó index y"),
-        // ("translation", "translation by x comma, y"), // Changes translation to comma
+        ("translation", "fordítás x vessző, y"), // Changes translation to comma
         ("constraint", "x feltétellel y"),
     ];
 


### PR DESCRIPTION
Hi,

@NSoiffer, final with #694 PR related happened a selective merge the affected files related to the hu branch.
Unfortunatelly, happened a mistake during merge with Rules/Languages/hu/definitions.yaml and tests/Languages/hu/definitions.rs file.
Very interesting, when in yesterday evening resolve a merge conflith with the two hu branches related, checks is passed.
This day morning when I doed the update to you upstream hu branch, the tests doesn't pass with definitions.yaml file related.
The problem I easy solved.
Because I always doing backup copyes the affected files with a PR related, I restore this files, and doed a squashed commit with fixing the error.

very short diff output is following, with affects only two files my squashed commit:
```
commit 223fbdaf556e1149a85b5a3cdd4efbc48ffee6c7
Author: Attila Hammer <hammera@pickup.hu>
Date:   Mon Aug 17 06:43:29 2026 +0200

    Fix a mistake after the selective merge with definitions.yaml and definition.rs test file
    
    Signed-off-by: Attila Hammer <hammera@pickup.hu>

diff --git a/Rules/Languages/hu/definitions.yaml b/Rules/Languages/hu/definitions.yaml
index c76b9454..d66738ec 100644
--- a/Rules/Languages/hu/definitions.yaml
+++ b/Rules/Languages/hu/definitions.yaml
@@ -87,14 +87,14 @@
     #"fraction":"function=fraction; over; end fraction", # NOTE: Fails
     "mixed-fraction":"infix=és", # NOTE: in website says function, but follow infix speech pattern.
     "greatest-common-divisor": "function=a legnagyobb közös osztó",
-    "quotient":"function=egész rész osztva", # NOTE: Logic somewhere here failing, becomes "divided by of x comma, y" instead of "integer part of x divided by y"
+    "quotient":"function=egész rész | osztva", # NOTE: Logic somewhere here failing, becomes "divided by of x comma, y" instead of "integer part of x divided by y"
     "evaluated-at":"infix=értékelve || postfix=értékként",
-    "remainder":"function=a maradék, osztva",
+    "remainder":"function=a maradék | osztva",
     "max":"function=max",
     "min":"function=min",
     "power":"infix=a hatványra",
     "root":"function=root",
-    "imaginary-part": "a képzeletbeli rész",
+    "imaginary-part": "function=a képzeletbeli rész: a képzeletbeli rész: a képzeletbeli rész",
     "least-common-multiple": "function=lcm: a legkisebb közös többszörös: a legkisebb közös többszörös",
     "complex-conjugate":"function=Komplex konjugált",
     "complex-arg":"function=argumentum",
@@ -131,15 +131,15 @@
     "tends-to-from-below":"infix=alulról indul",
     ### Sets
     "set": "function= ; halmaz: a halmaz",
-    "set-difference":"function=különbséghalmaz || infix=mínusz || postfix=különbséghalmaza", # NOTE: not tested
+    "set-difference":"function=különbséghalmaz | és || infix=mínusz",
     "complement":"function=komplemens",
-    "empty-set":"function=üres halmaz",
+    "empty-set":"nofix=üres halmaz",
     "cardinality":"function=számosság", # NOTE: does not have a defined speech template in website
     "list":"function=lista",
     "tuple": "function= ; tuple: a tuple",
     ### Sequence and Series
-    "sum":"function= ; összegzés : összeg ; ", #: sum over : sum from; to",
-    "product":"function=szorzat || function=szorzat vége || function=szorzat innen ide",
+    "sum": "function=összeg",
+    "product":"function=szorzat",
 
     ### Elementary classical functions
     "sine":"function=szinusz: szinusz",
@@ -225,6 +225,7 @@
     "highlight":"postfix=kiemelt",
     "least-common-denominator":"function=legkisebb közös nevező",
     "rate":"infix=per",
+    "translation":"function=fordítás",
     "constraint":"infix= ; feltétellel; ", 
 
     "binomial-coefficient":"infix=választ",
diff --git a/tests/Languages/hu/definitions.rs b/tests/Languages/hu/definitions.rs
index 542f4188..62f91018 100644
--- a/tests/Languages/hu/definitions.rs
+++ b/tests/Languages/hu/definitions.rs
@@ -32,7 +32,7 @@ fn my_set_basic() -> Result<()> {
       </math>
     "#;
 
-    test("hu", "ClearSpeak", expr, "az üres halmaz")?;
+    test("hu", "ClearSpeak", expr, "a halmaz x vessző, y")?;
 
     Ok(())
 }
@@ -91,7 +91,7 @@ fn set_difference_basic() -> Result<()> {
       </math>
     "#;
 
-    test( "hu", "ClearSpeak", expr, "különbséghalmaz nagy a vessző, nagy b")?;
+    test( "hu", "ClearSpeak", expr, "különbséghalmaz nagy a és nagy b")?;
 
     Ok(())
 }
@@ -107,7 +107,7 @@ fn postfix_test() -> Result<()> {
                 <mo>T</mo>
             </msup>
             "#,
-            "transzponált x",
+            "x transzponált",
         ),
         (
             "highlight",
@@ -205,9 +205,9 @@ fn functions_and_inverses_tests() -> Result<()> {
 
         //("fraction", "fraction x over y end fraction"),
         ("mixed-fraction", "x és y"),
-        ("quotient", "egész rész osztva x vessző, y"),
+        ("quotient", "egész rész x osztva y"),
         ("evaluated-at", "x értékelve y"),
-        ("remainder", "a maradék, osztva x vessző, y"),
+        ("remainder", "a maradék x osztva y"),
 
         ("max", "max x vessző, y vessző, z"),
         ("min", "min x vessző, y vessző, z"),
@@ -223,13 +223,13 @@ fn functions_and_inverses_tests() -> Result<()> {
 
         ("complex-conjugate", "Komplex konjugált x"),
         ("complex-arg", "argumentum x"),
-        ("real-part", "valós rész"),
-        ("imaginary-part", "képzetes rész"),
+        ("real-part", "az igazi rész x"),
+        ("imaginary-part", "a képzeletbeli rész x"),
 
         ("polar-coordinate", "poláris koordináta x vessző, y"),
         ("spherical-coordinate", "gömb koordináta x vessző, y vessző, z"),
         ("cartesian-coordinate", "derékszögű koordináta x vessző, y vessző, z"),
-        ("coordinate", "pont, x vessző y vessző z"),
+        ("coordinate", "koordináta x vessző, y vessző, z"),
 
         ("floor", "lépcső x"),
         ("ceiling", "mennyezet x"),
@@ -528,7 +528,7 @@ fn statistics_and_probability_tests() -> Result<()> {
         ("mode", "mód x"),
 
         // conditional probability typically two arguments
-        // ("conditional-probability", "probability of x given y"),
+        // ("conditional-probability", "valószínűség x adott y"),
     ];
 
     for (intent, expected) in tests {
@@ -576,7 +576,7 @@ fn linear_algebra_tests() -> Result<()> {
         ("span", "fesztávolság x"),
 
         // transpose supports both postfix and function; we test function explicitly
-        ("transpose", "transzponált x"),
+        ("transpose", "x transzponált"),
 
         // dimensional product is infix
         ("dimensional-product", "x a(z) y"),
@@ -727,13 +727,13 @@ fn general_concepts_tests() -> Result<()> {
         ("permutation-cycle", "permutációs ciklus x"),
 
         // Binary structural / infix-style
-        // ("ordered-pair", "the pair of x and y"),
+        ("ordered-pair", "a pár x és y"),
         ("rate", "x per y"),
         
         ("binomial-coefficient", "x választ y"),
         ("embellished-name", "x megjegyzéssel y"),
         ("indexed-by", "x alsó index y"),
-        // ("translation", "translation by x comma, y"), // Changes translation to comma
+        ("translation", "fordítás x vessző, y"), // Changes translation to comma
         ("constraint", "x feltétellel y"),
     ];
```

If you have a short time, please merge this squashed commit into the hu branch of github.com/daisy/mathcat repository, and please merge this updated hu branch to the main branch of with upstream repository.

Thank you the good cooperation, hu branch now contains one new commit

Attila
