### PR TITLE
ja: read fractions in Japanese word order

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -139,19 +139,21 @@
   - " BaseNode(*[2])[contains(@data-intent-property, ':unit')] )"
   replace:
   - x: "*[1]"
-  - t: "パーカー"      # phrase('5 meters 'per' second)
+  - t: "毎"      # phrase('5 meters 'per' second)
   - x: "*[2]"
 
 - name: common-fraction
   tag: fraction
   match:
   - "($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and"
-  - "*[1][self::m:mn][not(contains(., $DecimalSeparators)) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and"
-  - "*[2][self::m:mn][not(contains(., $DecimalSeparators)) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))]"
-  variables: [IsPlural: "*[1]!=1"]
+  - "*[1][self::m:mn][not(contains(., $DecimalSeparators))]   and"
+  - "*[2][self::m:mn][not(contains(., $DecimalSeparators))]"
   replace:
+  # Japanese says the denominator first: 3/4 is "4 分の 3". There is no separate ordinal
+  # form to build (unlike "three fourths"), so the pattern is uniform for any two numbers.
+  - x: "*[2]"
+  - t: "分の"      # phrase(the fraction 3 'over' 4)
   - x: "*[1]"
-  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
 
 - name: fraction-over-simple
   tag: fraction
@@ -168,14 +170,14 @@
           then: [ot: ""]
       - t: "分数"      # phrase(the 'fraction' with 3 over 4)
   - x: "*[1]"
-  - t: "分の"      # phrase(the fraction 3 'over' 4)
+  - t: "オーバー"      # phrase(the fraction 3 'over' 4)
   - x: "*[2]"
   - test:
       # very ugly!!! -- replicate nested ordinal fraction as they are an exception
       if: "$ClearSpeak_Fractions='OverEndFrac' or ($ClearSpeak_Fractions='EndFrac' and not( ($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and *[1][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] and *[2][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] ) )"
       then:
       - pause: short
-      - t: "分数終わり"      # phrase(7 over 8 'end fraction')
+      - t: "分数終了"      # phrase(7 over 8 'end fraction')
       - pause: short
 
 - # fraction with text or numbers followed by text in both numerator and denominator
@@ -197,13 +199,13 @@
   - ")"
   replace:
   - x: "*[1]"
-  - t: "分の"      # phrase(the fraction 3 'over' 4)
+  - t: "オーバー"      # phrase(the fraction 3 'over' 4)
   - x: "*[2]"
   - test:
       if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='OverEndFrac'"
       then:
       - pause: short
-      - t: "分数終わり"      # phrase(7 over 8 'end fraction')
+      - t: "分数終了"      # phrase(7 over 8 'end fraction')
       - pause: short
 
 - name: default
@@ -211,20 +213,20 @@
   match: "."
   replace:
   - ot: ""      # phrase(5 is 'the' square toot of 25)
-  - t: "分子 との 分数"      # phrase(the 'fraction with numerator' 6)
+  - t: "分数"      # phrase(the 'fraction with numerator' 6)
   - test:
       if: "not(IsNode(*[1], 'simple'))"
       then: [pause: medium]
   - x: "*[1]"
   - pause: medium
-  - t: "デノミネーター"      # phrase(the fraction with numerator 5 'and denominator' 8)
+  - t: "オーバー"      # phrase(the fraction with numerator 5 'and denominator' 8)
   - x: "*[2]"
   - pause: long
   - test:
       if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='GeneralEndFrac'"
       then:
       - pause: short
-      - t: "分数終わり"      # phrase(the fraction with 3 over 4 'end fraction')
+      - t: "分数終了"      # phrase(the fraction with 3 over 4 'end fraction')
       - pause: short
 
 # rules for functions raised to a power

--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -174,7 +174,7 @@
   - x: "*[2]"
   - test:
       # very ugly!!! -- replicate nested ordinal fraction as they are an exception
-      if: "$ClearSpeak_Fractions='OverEndFrac' or ($ClearSpeak_Fractions='EndFrac' and not( ($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and *[1][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] and *[2][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] ) )"
+      if: "$ClearSpeak_Fractions='OverEndFrac' or ($ClearSpeak_Fractions='EndFrac' and not( ($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and *[1][*[1][self::m:mn][not(contains(., '.'))]   and *[2][self::m:mn][not(contains(., '.'))] ] and *[2][*[1][self::m:mn][not(contains(., '.'))]   and *[2][self::m:mn][not(contains(., '.'))] ] ) )"
       then:
       - pause: short
       - t: "分数終了"      # phrase(7 over 8 'end fraction')
@@ -369,8 +369,8 @@
   - "     *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3
   # base is mn, mi, common fraction ([xxx] case)
   - "     *[1][self::m:mn or self::m:mi or "
-  - "          self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
-  - "                        *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "          self::m:fraction[*[1][self::m:mn][not(contains(., '.'))]   and"
+  - "                        *[2][self::m:mn][not(contains(., '.'))]]"
   - "         ]"
   - "    ]"
   replace:
@@ -389,8 +389,8 @@
   - "                *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3"
   # base is mn, mi, common fraction ([xxx] case)
   - "                *[1][self::m:mn or self::m:mi or "
-  - "                     self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
-  - "                                   *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "                     self::m:fraction[*[1][self::m:mn][not(contains(., '.'))]   and"
+  - "                                   *[2][self::m:mn][not(contains(., '.'))]]"
   - "               ]"
   - "          ]"
   - "     ]"
@@ -413,8 +413,8 @@
   - "       *[2][self::m:mo][.='⁢'] and " # invisible times
   # base is mn, or common fraction ([xxx] case)
   - "       *[1][self::m:mn or "
-  - "            self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
-  - "                          *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "            self::m:fraction[*[1][self::m:mn][not(contains(., '.'))]   and"
+  - "                          *[2][self::m:mn][not(contains(., '.'))]]"
   - "           ]"
   - "      ]"
   replace:
@@ -437,8 +437,8 @@
   - "       *[1][self::m:minus and count(*)=1 and "
   # base is mn, or common fraction ([xxx] case)
   - "            *[1][self::m:mn or "
-  - "                 self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
-  - "                                  *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "                 self::m:fraction[*[1][self::m:mn][not(contains(., '.'))]   and"
+  - "                                  *[2][self::m:mn][not(contains(., '.'))]]"
   - "                ]"
   - "           ]"
   - "      ]"

--- a/Rules/Languages/ja/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/ja/SimpleSpeak_Rules.yaml
@@ -83,12 +83,13 @@
 - name: common-fraction
   tag: fraction
   match:
-  - "*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
-  - "*[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]"
-  variables: [IsPlural: "*[1]!=1"]
+  - "*[1][self::m:mn][not(contains(., '.'))]   and"
+  - "*[2][self::m:mn][not(contains(., '.'))]"
   replace:
+  # Japanese says the denominator first: 3/4 is "4 分の 3".
+  - x: "*[2]"
+  - t: "分の"      # phrase(the fraction 3 'over' 4)
   - x: "*[1]"
-  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
 
 - name: common-fraction-mixed-number
   tag: fraction
@@ -96,10 +97,10 @@
   - "preceding-sibling::*[1][self::m:mo][.='⁤'] and" # preceding element is invisible plus
   - "*[1][self::m:mn][not(contains(., '.'))]   and"
   - "*[2][self::m:mn][not(contains(., '.'))]"
-  variables: [IsPlural: "*[1]!=1"]
   replace:
+  - x: "*[2]"
+  - t: "分の"      # phrase(the fraction 3 'over' 4)
   - x: "*[1]"
-  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
 
 
 # Units (e.g., meters per second, m^2/s^2, (3m^2)/s)
@@ -112,7 +113,7 @@
   - "BaseNode(*[2])[contains(@data-intent-property, ':unit')] "
   replace:
   - x: "*[1]"
-  - t: "パーカー"      # phrase('5 meters 'per' second)
+  - t: "毎"      # phrase('5 meters 'per' second)
   - x: "*[2]"
 
 - name: simple
@@ -125,7 +126,7 @@
   - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
   replace:
   - x: "*[1]"
-  - t: "分の"      # phrase(the fraction 3 'over' 4)
+  - t: "オーバー"      # phrase(the fraction 3 'over' 4)
   - x: "*[2]"
   - pause: short
 
@@ -141,7 +142,7 @@
   - test:
       if: "not(IsNode(*[1],'leaf'))"
       then: [pause: short]
-  - t: "分の"      # phrase(the fraction 3 'over' 4)
+  - t: "オーバー"      # phrase(the fraction 3 'over' 4)
   - test:
       if: "not(IsNode(*[2],'leaf'))"
       then: [pause: short]
@@ -149,7 +150,7 @@
   - pause: short
   - test:
       if: "$Impairment = 'Blindness'"
-      then: [t: "分数終わり"]      # phrase(start 7 over 8 'end of fraction')
+      then: [t: "分数終了"]      # phrase(start 7 over 8 'end of fraction')
   - pause: medium
 
 # rules for functions raised to a power

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -9,11 +9,33 @@ fn arithmetic_operators() -> Result<()> {
     return Ok(());
 }
 
-/// Verifies that a simple fraction is spoken with Japanese fraction wording.
+/// A fraction of two numbers is read denominator-first in Japanese:
+/// 21/22 is "22 分の 21", literally "of 22, 21". Reading it the other way round
+/// says 22/21.
 #[test]
 fn simple_fraction() -> Result<()> {
     let expr = "<math><mfrac><mn>21</mn><mn>22</mn></mfrac></math>";
-    test("ja", "ClearSpeak", expr, "21 分の 22")?;
+    test("ja", "ClearSpeak", expr, "22 分の 21")?;
+    test("ja", "SimpleSpeak", expr, "22 分の 21")?;
+    return Ok(());
+}
+
+/// The denominator-first pattern is not limited to the small numbers that English
+/// has ordinals for ("three fourths"); it is how any two numbers are read.
+#[test]
+fn numeric_fraction_large_denominator() -> Result<()> {
+    let expr = "<math><mfrac><mn>3</mn><mn>128</mn></mfrac></math>";
+    test("ja", "ClearSpeak", expr, "128 分の 3")?;
+    return Ok(());
+}
+
+/// When the parts are not plain numbers, Japanese keeps the written order and
+/// borrows the English preposition as "オーバー" instead (Yamaguchi et al. 1996).
+#[test]
+fn fraction_of_variables() -> Result<()> {
+    let expr = "<math><mfrac><mi>x</mi><mi>y</mi></mfrac></math>";
+    test("ja", "ClearSpeak", expr, "x オーバー y")?;
+    test("ja", "SimpleSpeak", expr, "x オーバー y")?;
     return Ok(());
 }
 


### PR DESCRIPTION
First of the small PRs promised in daisy/MathCAT#715. It fixes the one item in the seeded Japanese that changes the meaning of the maths rather than the wording.

### The problem

`simple_fraction` asserted 21/22 → 「21 分の 22」. In Japanese 「A 分の B」 is **B/A** — the denominator is spoken first — so the seeded rules and the seeded test agreed with each other that 21/22 should be spoken as 22/21.

### The rule I followed

> 山口雄仁・川根深・澤崎陽彦「日本語による数式読み上げ法の基本構成について」日本数学教育学会誌 78(9), 239–247 (1996), item (4)

If numerator and denominator are **both plain numbers**, use ordinary Japanese word order (denominator 分の numerator). Otherwise keep the written order and say 分数 A オーバー B 分数終了. Katsuhito Yamaguchi is behind ChattyInfty / InftyReader, the math TTS actually used by blind students in Japan.

### Changes

- `common-fraction` in both ClearSpeak and SimpleSpeak now emits `*[2]` 分の `*[1]`.
- Dropped the numeric range guards (`text()<20`, `2 <= text() <= 10`) and `ToOrdinal(..., true(), ...)` there. Those exist because English only has ordinals for small numbers; Japanese builds no separate ordinal form, so one pattern covers any pair of numbers.
- Every other fraction rule keeps the written order and now says オーバー rather than 分の, which would otherwise assert the opposite order.
- ClearSpeak's general fraction said 分子 との 分数 … デノミネーター; it now uses the same 分数 … オーバー … 分数終了 frame.
- 分数終わり → 分数終了, matching the reference's terminology (and the 根号終了 / 上付き終了 markers that will follow in later PRs).
- `per-fraction` said パーカー, which is a hooded sweatshirt. "5 meters per second" is 5 メートル 毎 秒.

### One definition, five copies

ClearSpeak copies the "both parts are plain numbers" predicate in five other places: the `EndFrac` test inside `fraction-over-simple` (twice, numerator and denominator) and the four `nested-*` exponent rules that ask whether the base is a common fraction. `grep -c "text()<20"` gave 5 in `ja` against 6 in `en`. With `common-fraction` widened and the copies left alone, 3/128 would have counted as a common fraction where it is spoken and not counted where those rules look, so the second commit brings all five to the same test.

No new tests for the `nested-*` shapes here: their wording (「に上げられた … パワー」) is itself wrong Japanese and belongs to the next PR, so pinning it now would only have to be rewritten.

### Tests

`simple_fraction` updated, and it now checks SimpleSpeak as well as ClearSpeak. Added `numeric_fraction_large_denominator` (3/128 — outside the old English ordinal range) and `fraction_of_variables` (x/y → x オーバー y, both styles).

### One thing to flag

This makes `audit-translations ja` report **5 rule differences** where `ja` currently reports 0 (measured both ways on this branch and on `ja`). They are the changed match pattern and the removed `variables: [IsPlural: ...]` in `common-fraction` and `common-fraction-mixed-number`.

The divergence is deliberate: those guards and that variable encode English morphology that Japanese does not have. @moritz-gross — you offered to help with `audit-translations`, so rather than opening a separate issue: is structural divergence from `en` something a language is allowed to do, or would you prefer the rule shape kept identical with the body made a no-op? I will follow whichever you want.
