### PR TITLE
ja: read exponents in Japanese

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -252,25 +252,20 @@
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][.='2']"
-      then: [t: "スクエア"]      # phrase(25 equals 5 'squared')
-      else: [t: "キューブド"]      # phrase(625 equals 5 'cubed')
+      then: [t: "の 2 乗"]      # phrase(25 equals 5 'squared')
+      else: [t: "の 3 乗"]      # phrase(625 equals 5 'cubed')
 
 - name: function-power
   tag: power
   match:
   - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
   replace:
-  - test:
-      if: "$Verbosity!='Terse'"
-      then: [ot: ""]      # phrase('the' third power of 2)
-  - bookmark: "*[2]/@id"
-  - test:
-      if: "*[2][self::m:mn][not(contains(., '.'))]"
-      then: [x: "ToOrdinal(*[2])"]
-      else: [x: "*[2]"]
-  - t: "パワーの"      # phrase(the third 'power of' 6)
-  - pause: short
   - x: "*[1]"
+  - t: "の"      # phrase(the third 'power of' 6)
+  - bookmark: "*[2]/@id"
+  - x: "*[2]"
+  - t: "乗"      # phrase(the third 'power of' 6)
+  - pause: short
 
 - name: AfterPower-nested
   tag: power
@@ -279,19 +274,20 @@
   - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
   replace:
   - x: "*[1]"
-  - t: "緊急事態に育つ"      # phrase(5 'raised to the exponent' x plus 1)
+  - t: "の上付き"      # phrase(5 'raised to the exponent' x plus 1)
   - pause: short
   - x: "*[2]"
   - pause: short
-  - t: "エンド指数"      # phrase(5 raised to the exponent x plus 1 'end exponent')
+  - t: "上付き終了"      # phrase(5 raised to the exponent x plus 1 'end exponent')
 
 - name: AfterPower-default
   tag: power
   match: "$ClearSpeak_Exponents = 'AfterPower'"
   replace:
   - x: "*[1]"
-  - t: "力に育つ"      # phrase(x is 'raised to the power' 4)
+  - t: "の"      # phrase(x is 'raised to the power' 4)
   - x: "*[2]"
+  - t: "乗"      # phrase(x is raised to the 'power' 4)
   - pause: short
 
 - name: squared
@@ -300,7 +296,7 @@
   replace:
   - x: "*[1]"
   - bookmark: "*[2]/@id"
-  - t: "スクエア"      # phrase(7 'squared' equals 49)
+  - t: "の 2 乗"      # phrase(7 'squared' equals 49)
 
 - name: cubed
   tag: power
@@ -308,7 +304,7 @@
   replace:
   - x: "*[1]"
   - bookmark: "*[2]/@id"
-  - t: "キューブド"      # phrase(5 'cubed' equals 125)
+  - t: "の 3 乗"      # phrase(5 'cubed' equals 125)
 
 - name: simple-integer
   tag: power
@@ -316,13 +312,8 @@
   replace:
   - x: "*[1]"
   - t: "の"      # phrase(2 raised 'to the' power 7)
-  - test:
-      if: "*[2][.>0]"
-      then: [x: "ToOrdinal(*[2])"]
-      else: [x: "*[2]"]
-  - test:
-      if: "$ClearSpeak_Exponents != 'Ordinal'"
-      then: [t: "パワー"]      # phrase(2 raised to the 'power' 7)
+  - x: "*[2]"
+  - t: "乗"      # phrase(2 raised to the 'power' 7)
 
 - name: simple-negative-integer
   tag: power
@@ -334,9 +325,7 @@
   - x: "*[1]"
   - t: "の"      # phrase(2 raised 'to the' power 7)
   - x: "*[2]"
-  - test:
-      if: "$ClearSpeak_Exponents != 'Ordinal'"
-      then: [t: "パワー"]      # phrase(2 raised to the 'power' 7)
+  - t: "乗"      # phrase(2 raised to the 'power' 7)
 
 - name: simple-var
   tag: power
@@ -345,10 +334,7 @@
   - x: "*[1]"
   - t: "の"      # phrase(3 raised 'to the' power 7)
   - x: "*[2]"
-  - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
-  - test:
-      if: "$ClearSpeak_Exponents != 'Ordinal'"
-      then: [t: "パワー"]      # phrase(2 raised to the 'power' 7)
+  - t: "乗"      # phrase(2 raised to the 'power' 7)
 
 # match nested exponent, where the nested exponent is has the power 2 or 3 (n below)
 #   [xxx]^n, - [xxx]^n, [xxx] var^n, -[xxx] var^n
@@ -373,9 +359,9 @@
   - "    ]"
   replace:
   - x: "*[1]"
-  - t: "に上げられた"      # phrase(x 'raised to the' second power)
+  - t: "の上付き"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "パワー"      # phrase(x raised to the second 'power')
+  - t: "上付き終了"      # phrase(x raised to the second 'power')
 
 - # - [xxx]^n
   name: nested-negative-squared-or-cubed
@@ -394,9 +380,9 @@
   - "     ]"
   replace:
   - x: "*[1]"
-  - t: "に上げられた"      # phrase(x 'raised to the' second power)
+  - t: "の上付き"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "パワー"      # phrase(x raised to the second 'power')
+  - t: "上付き終了"      # phrase(x raised to the second 'power')
 
 - # [xxx] var^n
   name: nested-var-squared-or-cubed
@@ -417,9 +403,9 @@
   - "      ]"
   replace:
   - x: "*[1]"
-  - t: "に上げられた"      # phrase(x 'raised to the' second power)
+  - t: "の上付き"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "パワー"      # phrase(x raised to the second 'power')
+  - t: "上付き終了"      # phrase(x raised to the second 'power')
 
 - # -[xxx] var^n
   name: nested-negative-var-squared-or-cubed
@@ -442,9 +428,9 @@
   - "      ]"
   replace:
   - x: "*[1]"
-  - t: "に上げられた"      # phrase(x 'raised to the' second power)
+  - t: "の上付き"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "パワー"      # phrase(x raised to the second 'power')
+  - t: "上付き終了"      # phrase(x raised to the second 'power')
 
 - name: default-exponent-power
   tag: power
@@ -452,20 +438,20 @@
   - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
   replace:
   - x: "*[1]"
-  - t: "緊急事態に育つ"      # phrase(x is 'raised to the exponent')
+  - t: "の上付き"      # phrase(x is 'raised to the exponent')
   - pause: short
   - x: "*[2]"
   - pause: short
-  - t: "エンド指数"      # phrase(and now 'end exponent' has been reached)
+  - t: "上付き終了"      # phrase(and now 'end exponent' has been reached)
 
 - name: default
   tag: power
   match: "."
   replace:
   - x: "*[1]"
-  - t: "に上げられた"      # phrase(x 'raised to the' second power)
+  - t: "の上付き"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "パワー"      # phrase(x raised to the second 'power')
+  - t: "上付き終了"      # phrase(x raised to the second 'power')
 
 #
 # Some rules on mrows

--- a/Rules/Languages/ja/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/ja/SimpleSpeak_Rules.yaml
@@ -172,24 +172,19 @@
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][.=2]"
-      then: [t: "スクエア"]      # phrase(5 'squared' equals 25)
-      else: [t: "キューブド"]      # phrase(5 'cubed' equals 125)
+      then: [t: "の 2 乗"]      # phrase(5 'squared' equals 25)
+      else: [t: "の 3 乗"]      # phrase(5 'cubed' equals 125)
 - name: function-power
   tag: power
   match:
   - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
   replace:
-  - test:
-      if: "$Verbosity!='Terse'"
-      then: [ot: ""]      # # phrase('the' fourth power of 10)
-  - bookmark: "*[2]/@id"
-  - test:
-      if: "*[2][self::m:mn][not(contains(., '.'))]"
-      then: [x: "ToOrdinal(*[2])"]
-      else: [x: "*[2]"]
-  - t: "パワーの"      # phrase(the fourth 'power of' 2)
-  - pause: short
   - x: "*[1]"
+  - t: "の"      # phrase(the fourth 'power of' 2)
+  - bookmark: "*[2]/@id"
+  - x: "*[2]"
+  - t: "乗"      # phrase(the fourth 'power of' 2)
+  - pause: short
 
 # non-function rules for power
 - name: squared-or-cubed
@@ -200,8 +195,8 @@
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][.=2]"
-      then: [t: "スクエア"]      # phrase(5 'squared' equals 25)
-      else: [t: "キューブド"]      # phrase(5 'cubed' equals 125)
+      then: [t: "の 2 乗"]      # phrase(5 'squared' equals 25)
+      else: [t: "の 3 乗"]      # phrase(5 'cubed' equals 125)
 
 - name: simple-integer
   tag: power
@@ -209,10 +204,9 @@
   replace:
   - x: "*[1]"
   - t: "の"      # phrase(15 raised 'to the' second power equals 225)
-  - test:
-      if: "*[2][.>0]"
-      then: [x: "ToOrdinal(*[2])"]
-      else: [x: "*[2]"]
+  - x: "*[2]"
+  - t: "乗"      # phrase(15 raised to the second 'power' equals 225)
+
 - name: simple-negative-integer
   tag: power
   match:
@@ -222,6 +216,8 @@
   - x: "*[1]"
   - t: "の"      # phrase(15 raised 'to the' second power equals 225)
   - x: "*[2]"
+  - t: "乗"      # phrase(15 raised to the second 'power' equals 225)
+
 - name: simple-var
   tag: power
   match: "*[2][self::m:mi][string-length(.)=1]"
@@ -229,7 +225,7 @@
   - x: "*[1]"
   - t: "の"      # phrase(15 raised 'to the' second power equals 225)
   - x: "*[2]"
-  - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
+  - t: "乗"      # phrase(15 raised to the second 'power' equals 225)
 
 - name: simple
   tag: power
@@ -238,6 +234,7 @@
   - x: "*[1]"
   - t: "の"      # phrase(15 raised 'to the' second power equals 225)
   - x: "*[2]"
+  - t: "乗"      # phrase(15 raised to the second 'power' equals 225)
 
 - name: nested
   # it won't end in "power" if the exponent is simple enough
@@ -251,13 +248,13 @@
   - "    ]"
   replace:
   - x: "*[1]"
-  - t: "に上げられた"      # phrase(15 'raised to the' second power equals 225)
+  - t: "の上付き"      # phrase(15 'raised to the' second power equals 225)
   - x: "*[2]"
   - pause: short
   - test:
       if: "$Impairment = 'Blindness'"
       then:
-      - t: "エンド指数"      # phrase(start 2 raised to the exponent 4 'end of exponent')
+      - t: "上付き終了"      # phrase(start 2 raised to the exponent 4 'end of exponent')
       - pause: short
       else:
       - pause: medium
@@ -267,9 +264,9 @@
   match: "."
   replace:
   - x: "*[1]"
-  - t: "に上げられた"      # phrase(15 'raised to the' second power equals 225)
+  - t: "の上付き"      # phrase(15 'raised to the' second power equals 225)
   - x: "*[2]"
-  - t: "パワー"      # phrase(15 raised to the second 'power' equals 225)
+  - t: "上付き終了"      # phrase(15 raised to the second 'power' equals 225)
   - pause: short
 
 #

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -62,14 +62,6 @@ fn variable_exponent() -> Result<()> {
     return Ok(());
 }
 
-/// A negative exponent keeps the same frame.
-#[test]
-fn negative_exponent() -> Result<()> {
-    let expr = "<math><msup><mi>x</mi><mrow><mo>&#x2212;</mo><mn>2</mn></mrow></msup></math>";
-    test("ja", "ClearSpeak", expr, "x の マイナス 2 乗")?;
-    return Ok(());
-}
-
 /// Verifies both Japanese gradient readings selected by verbosity.
 #[test]
 fn gradient() -> Result<()> {

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -62,6 +62,15 @@ fn variable_exponent() -> Result<()> {
     return Ok(());
 }
 
+/// A complex exponent is read as a superscript instead, with an explicit close:
+/// 「の上付き … 上付き終了」. Reading it as 乗 would end a nested exponent 「… 乗 乗」.
+#[test]
+fn complex_exponent() -> Result<()> {
+    let expr = "<math><msup><mi>x</mi><mrow><mi>y</mi><mo>+</mo><mn>1</mn></mrow></msup></math>";
+    test("ja", "SimpleSpeak", expr, "x の上付き y プラス 1 上付き終了")?;
+    return Ok(());
+}
+
 /// Verifies both Japanese gradient readings selected by verbosity.
 #[test]
 fn gradient() -> Result<()> {

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -25,11 +25,48 @@ fn square_root() -> Result<()> {
     return Ok(());
 }
 
-/// Verifies that a squared value uses the seeded Japanese exponent wording.
+/// An exponent is read "<base> の <exponent> 乗"; 乗 closes it. Japanese has no
+/// ordinal form here, so 2 is 2 and not "second".
 #[test]
 fn squared() -> Result<()> {
     let expr = "<math><msup><mn>3</mn><mn>2</mn></msup></math>";
-    test("ja", "ClearSpeak", expr, "3 スクエア")?;
+    test("ja", "ClearSpeak", expr, "3 の 2 乗")?;
+    test("ja", "SimpleSpeak", expr, "3 の 2 乗")?;
+    return Ok(());
+}
+
+/// Same shape for a cube.
+#[test]
+fn cubed() -> Result<()> {
+    let expr = "<math><msup><mn>5</mn><mn>3</mn></msup></math>";
+    test("ja", "ClearSpeak", expr, "5 の 3 乗")?;
+    test("ja", "SimpleSpeak", expr, "5 の 3 乗")?;
+    return Ok(());
+}
+
+/// The pattern does not change for exponents above three.
+#[test]
+fn integer_exponent() -> Result<()> {
+    let expr = "<math><msup><mi>x</mi><mn>5</mn></msup></math>";
+    test("ja", "ClearSpeak", expr, "x の 5 乗")?;
+    test("ja", "SimpleSpeak", expr, "x の 5 乗")?;
+    return Ok(());
+}
+
+/// A variable exponent is read the same way (English adds "-th" here; Japanese does not).
+#[test]
+fn variable_exponent() -> Result<()> {
+    let expr = "<math><msup><mi>x</mi><mi>n</mi></msup></math>";
+    test("ja", "ClearSpeak", expr, "x の n 乗")?;
+    test("ja", "SimpleSpeak", expr, "x の n 乗")?;
+    return Ok(());
+}
+
+/// A negative exponent keeps the same frame.
+#[test]
+fn negative_exponent() -> Result<()> {
+    let expr = "<math><msup><mi>x</mi><mrow><mo>&#x2212;</mo><mn>2</mn></mrow></msup></math>";
+    test("ja", "ClearSpeak", expr, "x の マイナス 2 乗")?;
     return Ok(());
 }
 


### PR DESCRIPTION
Second of the small PRs from daisy/MathCAT#715, and independent of #720 (different rules).

### How Japanese reads an exponent

> 山口雄仁・川根深・澤崎陽彦「日本語による数式読み上げ法の基本構成について」日本数学教育学会誌 78(9), 239–247 (1996), item (6)

- x² is 「x の 2 乗」 — base, の, exponent, 乗. **乗 is the closing marker**, and the reference says it is spoken as a matter of course for exponents.
- There is no ordinal form: 2 stays 2. Japanese does not say "the second power" the way English does, so `ToOrdinal` has nothing to build here, and the English `-th` pronunciation hint does not apply either.
- When the exponent is complex, the reference switches to reading it as a superscript instead: 「の上付き … 上付き終了」.

That second tier solves the problem the English comments in these files worry about. Because 乗 already closes a simple exponent, a nested exponent would otherwise end 「… 乗 乗」 — the exact analogue of "...power power". Using 上付き for the nested case avoids it.

### Changes

| was | now |
| --- | --- |
| 「スクエア」 (katakana "square") | 「の 2 乗」 |
| 「キューブド」 (katakana "cubed") | 「の 3 乗」 |
| 「パワー」 after a simple exponent | 「乗」 |
| 「パワーの」 ("power of") | reordered — see below |
| 「に上げられた」 ("was raised") | 「の上付き」 |
| 「エンド指数」 | 「上付き終了」 |
| 「緊急事態に育つ」 | 「の上付き」 |
| 「力に育つ」 | 「の」 (with 「乗」 added to close) |

The last two are worth spelling out: `raised to the exponent` had become 緊急事態に育つ, "to grow in an emergency", and `raised to the power` had become 力に育つ, "to grow into strength". Neither is about mathematics.

`function-power` needed reordering rather than a word swap. English puts the exponent first ("the fourth power of sine"); Japanese puts the base first — sin⁴ is 「サイン の 4 乗」 — so the rule now emits `*[1]`, 「の」, `*[2]`, 「乗」.

`ToOrdinal` and the `pronounce: [text: "-th", ...]` hint are removed from the power rules for the reason above. In ClearSpeak this also means `$ClearSpeak_Exponents = 'Ordinal'` no longer suppresses the closing 「乗」: that preference selects English's short ordinal form ("x squared" vs "x to the second power"), and Japanese has only the one form, so dropping 乗 there would leave 「x の 5」, which does not say that 5 is an exponent.

### Tests

`squared` updated, and now checks SimpleSpeak as well as ClearSpeak. Added `cubed`, `integer_exponent` (x⁵), and `variable_exponent` (xⁿ), each in both styles, plus `complex_exponent` (x^(y+1) → 「x の上付き y プラス 1 上付き終了」) so the superscript frame is pinned too.

Not covered here: negative exponents. x⁻² currently comes out as 「x の 負の 2 乗」, and 「マイナス 2 乗」 is what the reference's worked example implies (it reads −b as 「マイナス b」). But 負の/正の is the prefix reading of negative numbers generally, and 正の is correct where it appears in `general.yaml` for "the set of positive integers", so that is a separate change rather than something to slip in here.
