### PR TITLE
ja: read a leading minus as マイナス

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -41,8 +41,8 @@
       - bookmark: "*[1]/@id"
       - test:
           if: "parent::*[self::m:minus and count(*)=1]"
-          then: [t: "負の"]      # phrase(minus 4 is a 'negative' number)
-          else: [t: "正の"]      # phrase(10 is a 'positive' number)
+          then: [t: "マイナス"]      # phrase(minus 4 is a 'negative' number)
+          else: [t: "プラス"]      # phrase(10 is a 'positive' number)
   - t: "平方根"      # phrase(8 is the 'square root' of 64)
   - test:
       if: "$Verbosity!='Terse'"
@@ -74,8 +74,8 @@
           then: [bookmark: "parent/@id"]
       - test:
           if: "parent::m:minus"
-          then: [t: "負の"]      # phrase(minus 6 is a 'negative' number)
-          else: [t: "正の"]      # phrase(10 is a 'positive' number)
+          then: [t: "マイナス"]      # phrase(minus 6 is a 'negative' number)
+          else: [t: "プラス"]      # phrase(10 is a 'positive' number)
   - test:
       if: "*[2][self::m:mn and not(contains(., '.'))]"
       then_test:
@@ -121,8 +121,8 @@
       - bookmark: "@id"
       - test:
           if: "self::m:minus"
-          then: [t: "負の"]      # phrase(minus 5 is a 'negative' number)
-          else: [t: "正の"]      # phrase(7 is a 'positive' number)
+          then: [t: "マイナス"]      # phrase(minus 5 is a 'negative' number)
+          else: [t: "プラス"]      # phrase(7 is a 'positive' number)
   - x: "*[1]"
 
 # Fraction rules

--- a/Rules/Languages/ja/definitions.yaml
+++ b/Rules/Languages/ja/definitions.yaml
@@ -309,8 +309,8 @@
     "outer-product": "infix=外積",
     "parallel-to": "infix=平行へ",
     "perpendicular": "infix=垂直へ",
-    "plus": "infix=プラス || prefix=正の", # Prefix not tested
-    "minus": "infix=マイナス || prefix=負の", # Prefix not tested
+    "plus": "infix=プラス || prefix=プラス", # Prefix not tested
+    "minus": "infix=マイナス || prefix=マイナス", # Prefix not tested
     "plus-or-minus": "infix=プラスまたはマイナス",
     "precedes": "infix=に先行する",
     "proportional": "infix=比例する",

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -33,6 +33,17 @@ fn squared() -> Result<()> {
     return Ok(());
 }
 
+/// A leading minus is read マイナス, the same word as the binary operator.
+/// 負の / 正の name the *kind* of number (負の数 = "the negative numbers") and are
+/// not how −5 is read aloud.
+#[test]
+fn negative_number() -> Result<()> {
+    let expr = "<math><mo>&#x2212;</mo><mn>5</mn></math>";
+    test("ja", "ClearSpeak", expr, "マイナス 5")?;
+    test("ja", "SimpleSpeak", expr, "マイナス 5")?;
+    return Ok(());
+}
+
 /// Verifies both Japanese gradient readings selected by verbosity.
 #[test]
 fn gradient() -> Result<()> {


### PR DESCRIPTION
Third of the small PRs from daisy/MathCAT#715, independent of #720 and #721.

### What is wrong

A unary `+` or `-` was spoken 正の / 負の. Those name a *kind* of number — 負の数 is "the negative numbers" as a category — and they are not how −5 is read aloud. Japanese reads it マイナス 5, using the same word as the binary operator; there is no separate "negative" word the way English distinguishes "negative five" from "five minus".

The reference this series follows agrees: its worked example reads −b as 「マイナス b」, and the symbol table in its appendix gives ± as 「プラス・オア・マイナス」. 負の does not appear anywhere in it.

> 山口雄仁・川根深・澤崎陽彦「日本語による数式読み上げ法の基本構成について」日本数学教育学会誌 78(9), 239–247 (1996)

### Changes

Three pairs in `ClearSpeak_Rules.yaml` — the two `PosNegSqRoot` rules and `negative_and_positive` — and the `prefix=` forms of `plus` and `minus` in `definitions.yaml`.

**Deliberately not touched:** `SharedRules/general.yaml`, where 正の / 負の are correct. There they modify 整数 in "the set of all positive integers", which is exactly the categorical sense that makes them wrong as a reading of −5. A blanket replacement would have broken that, so the patch asserts that file is unchanged.

### Tests

`negative_number` (−5 → 「マイナス 5」) in both styles.

### Related

This is what #721 left out. There, x⁻² came out as 「x の 負の 2 乗」; with this change it reads 「x の マイナス 2 乗」. I did not add that test to either PR because it needs both changes; it belongs in whichever of the two merges second, or in a follow-up.

Also spotted while here, for a later PR rather than this one: `general.yaml` renders ℂ as 「複雑な数字」 ("complicated numbers") and ℕ as 「自然な数字」. The mathematical terms are 複素数 and 自然数.
