### PR TITLE
ja: read an n-th root as n 乗根

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -53,7 +53,7 @@
     - if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
       then:
       - pause: short
-      - t: "根号終わり"      # phrase(the square root of x 'end root')
+      - t: "根号終了"      # phrase(the square root of x 'end root')
       - pause: medium
     - else_if: "IsNode(*[1], 'simple')"
       then: [pause: short]
@@ -83,15 +83,10 @@
         then: [t: "平方根"]      # phrase(5 is the 'square root' of 25)
       - else_if: "*[2][.='3']"
         then: [t: "立方根"]      # phrase(5 is the 'cube root' of 625)
-      - else: [x: "ToOrdinal(*[2])", t: "根"]      # phrase(the square 'root' of 25)
+      - else: [x: "*[2]", t: "乗根"]      # phrase(the square 'root' of 25)
       else:
-      - test:
-          if: "*[2][self::m:mi][string-length(.)=1]"
-          then:
-          - x: "*[2]"
-          - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
-          else: [x: "*[2]"]
-      - t: "根"      # phrase(the square 'root' of 36)
+      - x: "*[2]"
+      - t: "乗根"      # phrase(the square 'root' of 36)
   - test:
       if: "$Verbosity!='Terse'"
       then: [t: "の"]      # phrase(the square root 'of' 36)
@@ -100,7 +95,7 @@
       if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
       then:
       - pause: short
-      - t: "根号終わり"      # phrase(start the fifth root of x 'end root')
+      - t: "根号終了"      # phrase(start the fifth root of x 'end root')
       - pause: medium
       else_test:
         if: "IsNode(*[1], 'simple')"

--- a/Rules/Languages/ja/SharedRules/default.yaml
+++ b/Rules/Languages/ja/SharedRules/default.yaml
@@ -124,7 +124,7 @@
   - test:
       if: "$Verbosity!='Terse'"
       then: [ot: ""]    # phrase("'the' root of x")
-  - t: "根"
+  - t: "ルート"
   - test:
       if: "$Verbosity!='Terse'"
       then: [t: "の"]    # phrase("the root 'of' x")
@@ -132,7 +132,7 @@
   - pause: short
   - test:
       if: "not(IsNode(*[1],'leaf')) or $Impairment = 'Blindness'"
-      then: [t: "根号終わり", pause: medium] # phrase("root of x 'end root symbol'")
+      then: [t: "根号終了", pause: medium] # phrase("root of x 'end root symbol'")
 
 # not sure what really should be said for these since we should not assume they are square roots
 - name: literal-default
@@ -142,7 +142,7 @@
   - test:
       if: "$Verbosity!='Terse'"
       then: [ot: ""]   # phrase("'the' root of x")
-  - t: "インデックスとルート" # phrase("the 'root with index' 3 of 5")
+  - t: "根指数" # phrase("the 'root with index' 3 of 5")
   - x: "*[1]"
   - pause: short
   - t: "の"              # phrase("the root 'of' x")
@@ -150,7 +150,7 @@
   - pause: short
   - test:
       if: "not(IsNode(*[2],'leaf'))"
-      then: [t: "エンドルートシンボル"] # phrase("root of x 'end root symbol'")
+      then: [t: "根号終了"] # phrase("root of x 'end root symbol'")
 
 
 - name: simple-sub

--- a/Rules/Languages/ja/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/ja/SimpleSpeak_Rules.yaml
@@ -44,7 +44,7 @@
   - pause: short
   - test:
       if: "not(IsNode(*[1], 'leaf')) and $Impairment = 'Blindness'"
-      then: [t: "根号終わり", pause: medium]  # phrase(start the square root of x 'end of root')
+      then: [t: "根号終了", pause: medium]  # phrase(start the square root of x 'end of root')
 
 - name: default
   tag: root
@@ -60,15 +60,10 @@
         then: [t: "平方根"]        # phrase(the 'square root' of x)
       - else_if: "*[2][.='3']"
         then: [t: "立方根"]        # phrase(the 'cube root' of x)
-      - else: [x: "ToOrdinal(*[2])", t: "根"]      # phrase(the square 'root' of 25)
+      - else: [x: "*[2]", t: "乗根"]      # phrase(the square 'root' of 25)
       else:
-      - test:
-          if: "*[2][self::m:mi][string-length(.)=1]"
-          then:
-          - x: "*[2]"
-          - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
-          else: [x: "*[2]"]
-      - t: "根"        # phrase(the square 'root' of)
+      - x: "*[2]"
+      - t: "乗根"        # phrase(the square 'root' of)
   - test:
       if: "$Verbosity!='Terse'"
       then: [t: "の"]        # phrase(the square root 'of' x)
@@ -76,7 +71,7 @@
   - pause: short
   - test:
       if: "not(IsNode(*[1], 'leaf')) and $Impairment = 'Blindness'"
-      then: [t: "根号終わり", pause: medium]  # phrase(start the square root of x 'end of root')
+      then: [t: "根号終了", pause: medium]  # phrase(start the square root of x 'end of root')
 
 # Fraction rules
 # Mixed numbers mostly "just work" because the invisible char reads as "and" and other parts read properly on their own

--- a/Rules/Languages/ja/overview.yaml
+++ b/Rules/Languages/ja/overview.yaml
@@ -51,15 +51,10 @@
       - else_if: "*[2][.='3']"
         then: [t: "立方根"]
       - else_if: "*[2][not(contains(., '.'))]"
-        then: [x: "ToOrdinal(*[2])", t: "根"]
+        then: [x: "*[2]", t: "乗根"]
       else:
-      - test:
-          if: "*[2][self::m:mi][string-length(.)=1]"
-          then:
-          - x: "*[2]"
-          - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
-          else: [x: "*[2]"]
-      - t: "根"
+      - x: "*[2]"
+      - t: "乗根"
   - test:
       if: "IsNode(*[1], 'simple')"
       then:

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -74,6 +74,24 @@ fn cube_root() -> Result<()> {
     return Ok(());
 }
 
+/// An n-th root is 「n 乗根」 -- the index, then 乗根. English builds an ordinal
+/// ("the fifth root"); Japanese has no such form and reads the number as it is.
+#[test]
+fn nth_root() -> Result<()> {
+    let expr = "<math><mroot><mi>x</mi><mn>5</mn></mroot></math>";
+    test("ja", "ClearSpeak", expr, "5 乗根 の x")?;
+    test("ja", "SimpleSpeak", expr, "5 乗根 の x")?;
+    return Ok(());
+}
+
+/// The same holds when the index is a variable (English appends "-th" here).
+#[test]
+fn variable_index_root() -> Result<()> {
+    let expr = "<math><mroot><mi>x</mi><mi>n</mi></mroot></math>";
+    test("ja", "ClearSpeak", expr, "n 乗根 の x")?;
+    return Ok(());
+}
+
 /// Verifies the basic Japanese SimpleSpeak subscript pattern.
 #[test]
 fn subscript() -> Result<()> {


### PR DESCRIPTION
Fourth of the small PRs from #715, independent of #720, #721 and #722.

### What is wrong

Four things in the root rules, all of them the English shape showing through.

1. **The index of an n-th root is built as an English ordinal.** `<mroot>` sent the index through `ToOrdinal(*[2])` and appended 「根」 -- the "the fifth root" shape. Japanese has no ordinal form here: the term is 「5 乗根」, the index followed by 乗根. Where the index was a single variable the rules went further and appended the literal `-th` pronunciation (θ), an English suffix with nothing to attach to.

2. **「根」 alone is not a spoken word.** In `SharedRules/default.yaml` an `<msqrt>` with no intent read as 「根」. The kanji means "root", but on its own it is not how the radical is named aloud; the reference gives 「平方根」 or 「ルート」.

3. **`<mroot>` with no intent said 「インデックスとルート」** -- a transliteration of the rule's own English comment, "the root with index 3 of 5". The Japanese term for the index of a radical is 根指数.

4. **The closing marker was inconsistent**: 「根号終わり」 in five places and 「エンドルートシンボル」 in one. The reference's term is 根号終了, which is also the form this series already uses (分数終了 in #720, 上付き終了 in #721).

> 山口雄仁・川根深・澤崎陽彦「日本語による数式読み上げ法の基本構成について」日本数学教育学会誌 78(9), 239-247 (1996)

Item (5) of the paper covers roots: a one-character radicand reads 「平方根 a」 or 「ルート a」, anything longer reads 「平方根オブ … 根号終了」.

### Changes

`ClearSpeak_Rules.yaml`, `SimpleSpeak_Rules.yaml` and `overview.yaml` -- index + 乗根, dropping `ToOrdinal` and the `-th` pronunciation. `SharedRules/default.yaml` -- ルート, 根指数, 根号終了.

**Deliberately not touched:** the 「の」 between 平方根 and its radicand. The reference drops the connective for a single-character radicand and uses 「オブ … 根号終了」 otherwise, so getting it right means keying the phrasing off a leaf test rather than `Verbosity` -- which changes the rule's shape relative to `en`. I asked about that class of divergence in #720 and in #715; I would rather have the answer than guess a third time.

### Tests

`nth_root` (index 5 -> 「5 乗根 の x」, both styles) and `variable_index_root` (index `n` -> 「n 乗根 の x」, the case that used to get `-th`).

### On the remaining ToOrdinal

`ToOrdinal` and the `-th` pronunciation still appear in the ja tree after this patch, in the fraction and power rules. #720 and #721 remove exactly those; between the three PRs none is left.
