### PR TITLE
ja: use the Japanese geometry terms

### DIFF
--- a/Rules/Languages/ja/SharedRules/geometry.yaml
+++ b/Rules/Languages/ja/SharedRules/geometry.yaml
@@ -7,12 +7,13 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "ラインセグメントから"      # phrase('the line segment from' A to B)
+      - t: "線分"      # phrase('the line segment from' A to B)
       - x: "*[1]"
-      - t: "に"                         # phrase(the line segment from A 'to' B)
+      - t: "から"                         # phrase(the line segment from A 'to' B)
       - x: "*[2]"
+      - t: "まで"                         # phrase(the line segment from A to B)
       else:
-      - t: "ラインセグメント"               # phrase(the 'line segment' A  B)
+      - t: "線分"               # phrase(the 'line segment' A  B)
       - x: "*[1]"
       - x: "*[2]"
 
@@ -23,12 +24,13 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "線から"             # phrase('the ray from' A to B)
+      - t: "半直線"             # phrase('the ray from' A to B)
       - x: "*[1]"
-      - t: "に"                       # phrase(the ray from A 'to' B)
+      - t: "から"                       # phrase(the ray from A 'to' B)
       - x: "*[2]"
+      - t: "まで"                       # phrase(the ray from A to B)
       else:
-      - t: "レイ"                      # phrase(the 'ray'A  B)
+      - t: "半直線"                      # phrase(the 'ray'A  B)
       - x: "*[1]"
       - x: "*[2]"
 
@@ -39,7 +41,7 @@
   - test:
       if: "$Verbosity='Verbose'"
       then: [ot: ""]            # phrase('the' arc A B C)
-  - t: "アーク"                        # phrase(the 'arc' A B C)
+  - t: "弧"                        # phrase(the 'arc' A B C)
   - x: "*[1]"
   - x: "*[2]"
 
@@ -50,9 +52,9 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "角度の測定"      # phrase('the measure of the angle' ABC)
+      - t: "角の大きさ"      # phrase('the measure of the angle' ABC)
       else:
-      - t: "角度の測定"      # phrase('measure of angle' ABC)
+      - t: "角の大きさ"      # phrase('measure of angle' ABC)
   - x: "*[1]"
   - x: "*[2]"
   - x: "*[3]"
@@ -66,10 +68,10 @@
   - test:
       if: "$Verbosity='Verbose'"
       then: [ot: ""]      # phrase('the' point at 1, 2)
-  - t: "ポイント"      # phrase(the 'point' at 1, 2)
+  - t: "点"      # phrase(the 'point' at 1, 2)
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "で"]      # phrase('the' point at 1, 2)
+      then: [t: "の座標"]      # phrase('the' point at 1, 2)
   - pause: short
   - insert:
       nodes: "*"
@@ -77,4 +79,4 @@
   - pause: short
   - test:
       if: "($SpeechStyle='ClearSpeak' and $Verbosity='Verbose') or not(IsNode(*[last()],'leaf'))"
-      then: [t: "エンドポイント"]      # phrase(start point, 'end point')
+      then: [t: "点終了"]      # phrase(start point, 'end point')

--- a/Rules/Languages/ja/SharedRules/geometry.yaml
+++ b/Rules/Languages/ja/SharedRules/geometry.yaml
@@ -26,9 +26,9 @@
       then:
       - t: "半直線"             # phrase('the ray from' A to B)
       - x: "*[1]"
-      - t: "から"                       # phrase(the ray from A 'to' B)
+      - t: "を始点として"           # phrase(the ray 'from' A to B) -- A is the endpoint
       - x: "*[2]"
-      - t: "まで"                       # phrase(the ray from A to B)
+      - t: "を通る"                   # phrase(the ray from A 'to' B) -- it passes through B, it does not stop there
       else:
       - t: "半直線"                      # phrase(the 'ray'A  B)
       - x: "*[1]"

--- a/Rules/Languages/ja/definitions.yaml
+++ b/Rules/Languages/ja/definitions.yaml
@@ -204,16 +204,16 @@
 
     
     ### Geometry
-    "line-segment":"prefix=ラインセグメント",
-    "directed-line-segment":"prefix=ラインセグメント", 
-    "line":"prefix=ライン",
-    "ray":"prefix=レイ",
-    "arc":"prefix=アーク",
+    "line-segment":"prefix=線分",
+    "directed-line-segment":"prefix=有向線分", 
+    "line":"prefix=直線",
+    "ray":"prefix=半直線",
+    "arc":"prefix=弧",
 
     "length":"function=長さ",
-    "area":"function=エリア",
+    "area":"function=面積",
 
-    "point":"prefix=ポイント",  ## NOTE: Has ??? for property in site. Should it be prefix? Or something else.
+    "point":"prefix=点",  ## NOTE: Has ??? for property in site. Should it be prefix? Or something else.
 
     ### Separators
     "time-separator":"infix=",
@@ -250,11 +250,11 @@
     "laplacian": "function=ラプラシアン",
 
     ## Default fixity prefix
-    "angle": "prefix=アングル",
-    "angle-measure": "prefix=角度測定",
+    "angle": "prefix=角",
+    "angle-measure": "prefix=角の大きさ",
     "change": "prefix=変更点",
     "for-all": "prefix=すべての",
-    "measured-angle": "prefix=測定角度",
+    "measured-angle": "prefix=測定角",
     "not": "prefix=でない",
     "number-of": "prefix=個数",
     "partial-derivative": "prefix=偏微分",

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -98,6 +98,33 @@ fn less_than() -> Result<()> {
     return Ok(());
 }
 
+/// Geometry has settled Japanese terms: 線分, 半直線, 弧, 点. The katakana
+/// transliterations of the English words are not used for these.
+#[test]
+fn geometry_terms() -> Result<()> {
+    for (intent, expected) in [
+        ("line-segment", "線分 x y"),
+        ("directed-line-segment", "有向線分 x y"),
+        ("line", "直線 x y"),
+        ("ray", "半直線 x y"),
+        ("arc", "弧 x y"),
+    ] {
+        let expr = format!(
+            "<math><mrow intent='{intent}($x,$y)'><mi arg='x'>x</mi><mi arg='y'>y</mi></mrow></math>"
+        );
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// A point is 点, not ポイント.
+#[test]
+fn geometry_point() -> Result<()> {
+    let expr = "<math><mrow intent='point($x,$y,$z)'><mi arg='x'>x</mi><mi arg='y'>y</mi><mi arg='z'>z</mi></mrow></math>";
+    test("ja", "ClearSpeak", expr, "点 x y z")?;
+    return Ok(());
+}
+
 /// Verifies that common lowercase Greek letters use their Japanese names.
 #[test]
 fn greek_letters() -> Result<()> {

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -125,6 +125,18 @@ fn geometry_point() -> Result<()> {
     return Ok(());
 }
 
+/// Verbose keeps the head term first, as the reference asks, but a ray and a
+/// segment differ in what the second point is: a segment stops at it, a ray only
+/// passes through it. 「まで」 would claim the ray ends at B.
+#[test]
+fn geometry_verbose_from_to() -> Result<()> {
+    let seg = "<math><mrow intent='line-segment($x,$y)'><mi arg='x'>x</mi><mi arg='y'>y</mi></mrow></math>";
+    test_prefs("ja", "ClearSpeak", vec![("Verbosity", "Verbose")], seg, "線分 x から y まで")?;
+    let ray = "<math><mrow intent='ray($x,$y)'><mi arg='x'>x</mi><mi arg='y'>y</mi></mrow></math>";
+    test_prefs("ja", "ClearSpeak", vec![("Verbosity", "Verbose")], ray, "半直線 x を始点として y を通る")?;
+    return Ok(());
+}
+
 /// Verifies that common lowercase Greek letters use their Japanese names.
 #[test]
 fn greek_letters() -> Result<()> {


### PR DESCRIPTION
Fifth of the small PRs from #715, independent of #720, #721, #722 and #723.

### What is wrong

The seeded geometry rules and the geometry entries of `definitions.yaml` transliterate the English words rather than use the Japanese terms. For this area the terms are completely settled -- they are what a textbook introduces in the first year of junior high.

| | seeded | term |
|---|---|---|
| line segment | ラインセグメント | 線分 |
| directed line segment | ラインセグメント | 有向線分 |
| line | ライン | 直線 |
| ray | レイ | 半直線 |
| arc | アーク | 弧 |
| point | ポイント | 点 |
| area | エリア | 面積 |
| angle | アングル | 角 |
| angle measure | 角度測定 / 角度の測定 | 角の大きさ |

Two of these are more than word choice:

- `line-segment` and `directed-line-segment` were both ラインセグメント, so the distinction between them disappeared.
- 角度測定 reads as "measuring an angle measure" -- 角度 already *is* the measure of an angle. The quantity is 角の大きさ.

The Verbose branches were English word order carried over with the wrong particles (「ラインセグメントから A に B」); they now read 「線分 A から B まで」.

### A ray does not stop at its second point

`en` says "the ray from A to B", where "to" means "in the direction of". Rendering that with 「まで」 claims the ray *ends* at B. A ray has A as its endpoint and continues through B without end, so Verbose reads 「半直線 A を始点として B を通る」. A segment does end at its second point, so から...まで is right there. The second commit fixes this and adds a test that pins the two apart; CodeRabbit caught it on my preflight branch.

### Deliberately not touched

- **The word order.** 「AからBまでの線分」 is more idiomatic prose, but the reference this series follows opens by saying to keep to the English reading order and not presuppose reversal, and postposing the head term is the kind of structural divergence from `en` I asked about in #720 and #715.
- **アークタンジェント and the other inverse trig names**, which are correct as they stand -- only the geometric アーク is a transliteration.

> 山口雄仁・川根深・澤崎陽彦「日本語による数式読み上げ法の基本構成について」日本数学教育学会誌 78(9), 239-247 (1996)

### Tests

`geometry_terms` (the five intent forms), `geometry_point`, and `geometry_verbose_from_to` (segment against ray under Verbose).

### Spotted, left for later

In the same block of `definitions.yaml`, `change` (Δ) is 変更点, "a point that was changed"; the quantity is 変化量.
