### PR TITLE
ja: read brackets and absolute value in Japanese

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -468,14 +468,13 @@
       if: "$Verbosity!='Terse'"
       then: [ot: ""]      # phrase('the' absolute value of 25)
   - x: "$WordToSay"
-  - t: "の"      # phrase(the absolute value 'of' 25)
   - x: "*[1]"
   - test:
       if: "$ClearSpeak_AbsoluteValue = 'AbsEnd'"
       then:
       - pause: short
-      - t: "リリース"      # phrase('end' absolute value)
       - x: "$WordToSay"
+      - t: "閉じ"      # phrase('end' absolute value)
   - pause: short
 
 - name: set

--- a/Rules/Languages/ja/unicode.yaml
+++ b/Rules/Languages/ja/unicode.yaml
@@ -84,16 +84,16 @@
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then_test:
             if: "$Verbosity='Terse'"
-            then: [t: "開き"]                     # 0x28
-            else: [t: "開き丸括弧"]               # 0x28
+            then: [t: "括弧"]                     # 0x28
+            else: [t: "丸括弧"]               # 0x28
         else: [t: "左丸括弧"]                   # 0x28                         
  - ")":                                          # 0x29
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then_test:
             if: "$Verbosity='Terse'"
-            then: [t: "閉じ"]                   # 0x29
-            else: [t: "閉じ丸括弧"]             # 0x29
+            then: [t: "括弧閉じ"]                   # 0x29
+            else: [t: "丸括弧閉じ"]             # 0x29
         else: [t: "右丸括弧"]                 # 0x29                 
 
  - "*":                                          # 0x2a
@@ -155,14 +155,14 @@
  - "[":                                          # 0x5b
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "オープンブラケット"]
-        else: [t: "左ブラケット"]                            
+        then: [t: "角括弧"]
+        else: [t: "左角括弧"]                            
  - "\\": [t: "バックスラッシュ"]                         # 0x5c
  - "]":                                          # 0x5d
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "クローズブラケット"]
-        else: [t: "右ブラケット"]
+        then: [t: "角括弧閉じ"]
+        else: [t: "右角括弧"]
  - "^":                                           # 0x5e
     - test:
         if: "parent::m:modified-variable or parent::m:mover"
@@ -173,8 +173,8 @@
  - "{":                                         # 0x7b
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "オープンブレイス"]
-        else: [t: "左の括弧"]                            
+        then: [t: "中括弧"]
+        else: [t: "左中括弧"]                            
  - "|":                                          # 0x7c
     # note: for ClearSpeak and SimpleSpeak, "|" inside of sets is handled at the mrow level, same for 'sets'
      - with:
@@ -202,8 +202,8 @@
  - "}":                                          # 0x7d
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "クローズ ブラス"]
-        else: [t: "右括弧"]                            
+        then: [t: "中括弧閉じ"]
+        else: [t: "右中括弧"]                            
 
  - "~": [t: "チルド"]                               # 0x7e
  - " ":                                            # 0xa0

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -125,7 +125,7 @@ fn multiplication_and_division() -> Result<()> {
 #[test]
 fn parenthesized_expression() -> Result<()> {
     let expr = "<math><mrow><mo>(</mo><mn>1</mn><mo>+</mo><mn>2</mn><mo>)</mo></mrow></math>";
-    test("ja", "ClearSpeak", expr, "丸括弧, 1 プラス 2, 丸括弧閉じ")?;
+    test("ja", "ClearSpeak", expr, "丸括弧 1 プラス 2, 丸括弧閉じ")?;
     return Ok(());
 }
 
@@ -134,9 +134,9 @@ fn parenthesized_expression() -> Result<()> {
 #[test]
 fn square_and_curly_brackets() -> Result<()> {
     let square = "<math><mrow><mo>[</mo><mn>1</mn><mo>+</mo><mn>2</mn><mo>]</mo></mrow></math>";
-    test("ja", "ClearSpeak", square, "角括弧, 1 プラス 2, 角括弧閉じ")?;
+    test("ja", "ClearSpeak", square, "角括弧 1 プラス 2, 角括弧閉じ")?;
     let curly = "<math><mrow><mo>{</mo><mn>1</mn><mo>+</mo><mn>2</mn><mo>}</mo></mrow></math>";
-    test("ja", "ClearSpeak", curly, "中括弧, 1 プラス 2, 中括弧閉じ")?;
+    test("ja", "ClearSpeak", curly, "中括弧 1 プラス 2, 中括弧閉じ")?;
     return Ok(());
 }
 
@@ -153,7 +153,7 @@ fn absolute_value() -> Result<()> {
 #[test]
 fn absolute_value_abs_end() -> Result<()> {
     let expr = "<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>";
-    test_ClearSpeak("ja", "AbsoluteValue", "AbsEnd", expr, "絶対値 x, 絶対値 閉じ")?;
+    test_ClearSpeak("ja", "ClearSpeak_AbsoluteValue", "AbsEnd", expr, "絶対値 x, 絶対値 閉じ")?;
     return Ok(());
 }
 

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -125,7 +125,18 @@ fn multiplication_and_division() -> Result<()> {
 #[test]
 fn parenthesized_expression() -> Result<()> {
     let expr = "<math><mrow><mo>(</mo><mn>1</mn><mo>+</mo><mn>2</mn><mo>)</mo></mrow></math>";
-    test("ja", "ClearSpeak", expr, "開き丸括弧, 1 プラス 2, 閉じ丸括弧")?;
+    test("ja", "ClearSpeak", expr, "丸括弧, 1 プラス 2, 丸括弧閉じ")?;
+    return Ok(());
+}
+
+/// Square and curly brackets follow the same pattern: the opening bracket names
+/// the shape and the closing one adds the postposed cue (Yamaguchi et al. 1996).
+#[test]
+fn square_and_curly_brackets() -> Result<()> {
+    let square = "<math><mrow><mo>[</mo><mn>1</mn><mo>+</mo><mn>2</mn><mo>]</mo></mrow></math>";
+    test("ja", "ClearSpeak", square, "角括弧, 1 プラス 2, 角括弧閉じ")?;
+    let curly = "<math><mrow><mo>{</mo><mn>1</mn><mo>+</mo><mn>2</mn><mo>}</mo></mrow></math>";
+    test("ja", "ClearSpeak", curly, "中括弧, 1 プラス 2, 中括弧閉じ")?;
     return Ok(());
 }
 
@@ -133,7 +144,16 @@ fn parenthesized_expression() -> Result<()> {
 #[test]
 fn absolute_value() -> Result<()> {
     let expr = "<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>";
-    test("ja", "ClearSpeak", expr, "絶対値 の x")?;
+    test("ja", "ClearSpeak", expr, "絶対値 x")?;
+    return Ok(());
+}
+
+/// With AbsEnd the closing cue is spoken after the contents, not before it, so
+/// the bar that ends the group is heard where it actually is.
+#[test]
+fn absolute_value_abs_end() -> Result<()> {
+    let expr = "<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>";
+    test_ClearSpeak("ja", "AbsoluteValue", "AbsEnd", expr, "絶対値 x, 絶対値 閉じ")?;
     return Ok(());
 }
 


### PR DESCRIPTION
Follows #720, #721 and #722 on the `ja` branch.

### Brackets

The seeded wording transliterated the English cues and kept the English word order, so the closing cue was spoken *before* the group it closes (`閉じ丸括弧`, literally "close paren"). Japanese names the shape when the group opens and postposes the closing cue (Yamaguchi, Kawane and Sawazaki 1996, item 8):

| | open | close |
|---|---|---|
| `(` `)` | 丸括弧 (Terse: 括弧) | 丸括弧閉じ (Terse: 括弧閉じ) |
| `[` `]` | 角括弧 | 角括弧閉じ |
| `{` `}` | 中括弧 | 中括弧閉じ |

The Terse/Verbose split is the one `en` already has: 丸, the word for the shape, drops out in Terse exactly as "paren" does in English.

This also fixes three machine-translation slips: `クローズ ブラス` (from "close brace"), `オープンブレイス`, and `左の括弧` for `{`.

### Absolute value

`|x|` was read `絶対値 の x`. That is ungrammatical: Japanese `の` attaches the other way round, so "the absolute value of x" would have to be `x の絶対値`. Item 1 of the same paper says not to reorder into Japanese word order, and item 8 gives the reading for `|…|`, so the fix is to keep the written order and drop the preposition: `|x|` is now `絶対値 x`.

With `ClearSpeak_AbsoluteValue = AbsEnd` the closing cue is a closing delimiter, so it now comes after the contents instead of before them, and `リリース` ("release", a transliteration of "end") becomes `閉じ`.

### Checks

- `audit-translations ja`: **Rule differences unchanged at 22**, untranslated 3681 to 3680. I measured the baseline on `ja` first, so the 22 is pre-existing and this branch does not widen the structural gap.
- Test expectations are the actual output taken from CI rather than guesses. Added `square_and_curly_brackets` and `absolute_value_abs_end`.

### Deliberately not in this PR

`unicode-full.yaml` has roughly 107 more bracket names in the same shape (`トップ亀甲シェルブラケット` and so on), and `⟨`/`⟩` are `左角ブラケット`/`直角ブラケット` — the second translated the direction word "right" as "right angle". I have left that file alone because NSoiffer mentioned in #715 that MathPlayer Japanese data could seed the unicode files, and hand-editing a table that is about to be replaced seemed wasteful. Happy to do it now instead if you would rather not wait.
