### PR TITLE
ja: read large operators in Japanese word order

### DIFF
--- a/Rules/Languages/ja/SharedRules/general.yaml
+++ b/Rules/Languages/ja/SharedRules/general.yaml
@@ -156,14 +156,14 @@
       if: "$Verbosity!='Terse'"
       then: [ot: ""]      # phrase('the' square root of 25 equals 5)
   - x: "*[1]"
-  - t: "から"      # phrase(subtracting 5 'from' 10 gives 5)
   - x: "*[2]"
+  - t: "から"      # phrase(subtracting 5 'from' 10 gives 5)
   - pause: short
-  - t: "に"      # phrase(adding 6 'to' 6 equals  12)
   - x: "*[3]"
+  - t: "まで"      # phrase(adding 6 'to' 6 equals  12)
   - test:
       if: "following-sibling::*"
-      then: [t: "の"]      # phrase(the square root 'of' 25 equals 5)
+      then: [t: "オブ"]      # phrase(the square root 'of' 25 equals 5)
 
 - name: bigop-under
   tag: large-op
@@ -173,11 +173,11 @@
       if: "$Verbosity!='Terse'"
       then: [ot: ""]      # phrase('the' square root of 25 equals 5)
   - x: "*[1]"
-  - t: "分の"      # phrase(2 'over' 3 equals two thirds)
   - x: "*[2]"
+  - t: "にわたる"      # phrase(2 'over' 3 equals two thirds)
   - test:
       if: "following-sibling::*"
-      then: [t: "の"]      # phrase(the square root 'of' 25 equals 5)
+      then: [t: "オブ"]      # phrase(the square root 'of' 25 equals 5)
 
 - name: largeop
   tag: mrow

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -246,7 +246,23 @@ fn set_membership() -> Result<()> {
 #[test]
 fn summation() -> Result<()> {
     let expr = "<math><munderover><mo>&#x2211;</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mi>i</mi></math>";
-    test("ja", "SimpleSpeak", expr, "総和 から i イコール 1, に n の i")?;
+    test("ja", "SimpleSpeak", expr, "総和 i イコール 1 から, n まで オブ i")?;
+    return Ok(());
+}
+
+/// A large operator with only a lower limit takes the postposed "over" cue.
+#[test]
+fn summation_lower_limit_only() -> Result<()> {
+    let expr = "<math><munder><mo>&#x2211;</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow></munder><mi>i</mi></math>";
+    test("ja", "SimpleSpeak", expr, "総和 i イコール 1 にわたる オブ i")?;
+    return Ok(());
+}
+
+/// The same shape is used for the other large operators.
+#[test]
+fn product_with_limits() -> Result<()> {
+    let expr = "<math><munderover><mo>&#x220F;</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mi>i</mi></math>";
+    test("ja", "SimpleSpeak", expr, "総積 i イコール 1 から, n まで オブ i")?;
     return Ok(());
 }
 
@@ -254,6 +270,6 @@ fn summation() -> Result<()> {
 #[test]
 fn definite_integral() -> Result<()> {
     let expr = "<math><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mi>x</mi><mo>&#x2146;</mo><mi>x</mi></math>";
-    test("ja", "SimpleSpeak", expr, "積分 から 0, に 1 の; x 微分 d x")?;
+    test("ja", "SimpleSpeak", expr, "積分 0 から, 1 まで オブ; x 微分 d x")?;
     return Ok(());
 }

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -262,7 +262,7 @@ fn summation_lower_limit_only() -> Result<()> {
 #[test]
 fn product_with_limits() -> Result<()> {
     let expr = "<math><munderover><mo>&#x220F;</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn></mrow><mi>n</mi></munderover><mi>i</mi></math>";
-    test("ja", "SimpleSpeak", expr, "総積 i イコール 1 から, n まで オブ i")?;
+    test("ja", "SimpleSpeak", expr, "プロダクト i イコール 1 から, n まで オブ i")?;
     return Ok(());
 }
 


### PR DESCRIPTION
Follows #725 on the `ja` branch. Same class of problem as the brackets PR: the English preposition order was kept, and the Japanese equivalents are postpositions.

### Sums, products and integrals

`bigop-both` (a large operator with both limits) read the sum from 1 to n of i as

    総和 から i イコール 1, に n の i

which places each preposition where English puts it. Japanese marks a range with the postpositions から … まで, so the limits come first:

    総和 i イコール 1 から, n まで オブ i

This is item 6 of Yamaguchi, Kawane and Sawazaki (1996), which gives the reading for a summation as サム i イコール 1 から n まで（オブ）… and for a definite integral as インテグラル a から b まで（オブ）….

The trailing connective becomes オブ rather than の. 「n までの i」 is grammatical Japanese, but it means "i, from 1 to n" — の attaches the operand to the *range* instead of introducing the summand, so the listener hears the wrong parse. Item 3 of the same paper is why the borrowed オブ is the right form here (the paper introduces オブ and オーバー as loan prepositions for exactly this purpose).

`bigop-under` (lower limit only) used 分の for "over". 分の is the fraction word — 「A 分の B」 is B/A — so a sum with a single limit was read as if a fraction were involved. It is now にわたる, which is the word this repo's own `definitions.yaml` already uses for the `sum` intent (`function=総和 | にわたる | から,まで`).

### Checks

- `audit-translations ja`: unchanged. Rule differences 28 and untranslated 3683, both before and after. I measured the baseline on a detached checkout of `ja` at 544e7fb4 rather than reusing an earlier number, since `ja` moved while I was working.
- Test expectations are the actual CI output, not guesses. Added `summation_lower_limit_only` and `product_with_limits`.

### Deliberately not changed

The operator names themselves — 総和 for ∑, 積分 for ∫, プロダクト for ∏ — are left alone. They are correct Japanese, and the cited paper's appendix offers サム / 大文字シグマ for ∑ as alternatives rather than corrections.

The interval rules (`intervals` in `SharedRules/general.yaml` and `ClearSpeak-intervals`) have the same から … に shape and need the same fix, but they also need decisions this PR does not: 間隔 should be 区間 (間隔 means spacing, not a mathematical interval), and the "not including" wording currently reads コメントはありません — "there are no comments", from translating the bare word "not". I would rather send that separately.
