### PR TITLE
ja: read intervals with a verb on each endpoint

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -512,6 +512,7 @@
   # does not distribute over a disjunction the way it does in English, so a literal または would say
   # "not(a) or not(b)". Each endpoint therefore carries its own verb, joined by the continuative form.
   name: ClearSpeak-intervals # avoid overriding with default "intervals" name
+  # audit-ignore -- the clause structure intentionally differs from en (see comment above)
   variables:
   - is_intervals_start_infinity: "*[1][self::m:minus and count(*)=1 and *[1][.='∞']]"
   - is_intervals_end_infinity: "*[2][.='∞'or (self::m:plus and count(*)=1 and *[1][.='∞'])]"

--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -504,54 +504,52 @@
           - t: "セット"      # phrase(this is a 'set' of integers)
       - x: "*[1]"
 
-- # intervals are controlled by a ClearSpeak Preference -- parens/brackets don't have to match, so we avoid IsBracketed
+- # intervals are controlled by a ClearSpeak Preference -- parens/brackets do not have to match, so we avoid IsBracketed
   # alternatively, we could have four (or ten) rules, but there is a lot of duplication if we do that
   # this one rule handles all ten cases listed as part $ClearSpeak_Paren = 'Interval'
   # note that *[2] is an mrow with X, ",", Y, so getting X or Y is a double index
+  # The English rule says "not including a or b". Japanese cannot copy that slot by slot: the negation
+  # does not distribute over a disjunction the way it does in English, so a literal または would say
+  # "not(a) or not(b)". Each endpoint therefore carries its own verb, joined by the continuative form.
   name: ClearSpeak-intervals # avoid overriding with default "intervals" name
   variables:
   - is_intervals_start_infinity: "*[1][self::m:minus and count(*)=1 and *[1][.='∞']]"
   - is_intervals_end_infinity: "*[2][.='∞'or (self::m:plus and count(*)=1 and *[1][.='∞'])]"
+  - is_start_closed: "name(.)='closed-interval' or name(.)='closed-open-interval'"
+  - is_end_closed: "name(.)='closed-interval' or name(.)='open-closed-interval'"
   tag: [open-interval, open-closed-interval, closed-interval, closed-open-interval]
   match: "."
   replace:
-  - t: "間隔から"      # phrase('the interval from' a to b)
+  - t: "区間"      # phrase('the interval from' a to b)
   - x: "*[1]"
-  - t: "に"      # phrase(the interval from a 'to' b)
+  - t: "から"      # phrase(the interval from a 'to' b)
   - x: "*[2]"
+  - t: "まで"      # phrase(the interval from a 'to' b)
   - pause: short
+    # each endpoint takes its own verb; the first one is continuative unless it is the only clause
   - test:
       if: "not($is_intervals_start_infinity)"
       then:
-      - test:
-          if: "starts-with(name(.), 'open')"
-          then: [t: "コメントはありません"]      # phrase(the interval from a to b 'not' including b)
-      - t: "含まれるもの"      # phrase(the interval from a to b not 'including' b)
       - x: "*[1]"
-    # logic to deal with [not] arg #1
-  - test:
-      if: "not($is_intervals_start_infinity or $is_intervals_end_infinity)"
-      then_test:
-      - if: "name(.)='open-interval'"
-        then: [t: "または"]      # phrase(the interval including a 'or' b )
-      - else_if: "name(.)='closed-interval'"
-        then: [t: "および"]      # phrase(the interval including a 'and' b)
-        else: [t: "しかし、"]      # phrase(the interval including a 'but' not b)
-    # some ugly logic dealing with connectives: or, but, but, and (cleaner to be part of next clause?)
+      - test:
+          if: "$is_start_closed"
+          then_test:
+            if: "$is_intervals_end_infinity"
+            then: [t: "を含む"]      # phrase(the interval from a to b 'including' b)
+            else: [t: "を含み"]      # phrase(the interval from a to b 'including' b)
+          else_test:
+            if: "$is_intervals_end_infinity"
+            then: [t: "を含まない"]      # phrase(the interval from a to b 'not' including b)
+            else: [t: "を含まず"]      # phrase(the interval from a to b 'not' including b)
   - test:
       if: "not($is_intervals_end_infinity)"
       then:
-      - test:
-          # there is some asymmetry to the test because of the and/or/but logic above
-          if: "not( name(.)='open-interval' or name(.)='closed-interval' ) or $is_intervals_start_infinity"
-          then:
-          - test:
-              if: "name(.) = 'open-interval' or name(.) = 'closed-open-interval'"
-              then: [t: "コメントはありません"]      # phrase(the interval 'not' including a)
-          - t: "含まれるもの"      # phrase(the interval not 'including' a)
       - x: "*[2]"
+      - test:
+          if: "$is_end_closed"
+          then: [t: "を含む"]      # phrase(the interval not 'including' a)
+          else: [t: "を含まない"]      # phrase(the interval 'not' including a)
 
-    # onto the [not] [including]... part
 - name: binomial-frac-vector
   tag: matrix
   match:

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -157,6 +157,42 @@ fn absolute_value_abs_end() -> Result<()> {
     return Ok(());
 }
 
+/// The four bounded interval forms. English says "not including c or d"; a slot-by-slot
+/// translation would use または and change the meaning, because negation does not
+/// distribute over a Japanese disjunction. Each endpoint takes its own verb instead,
+/// with the first in the continuative form.
+#[test]
+fn interval_open_open() -> Result<()> {
+    let expr = "<math><mrow><mo>(</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>)</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含まず d を含まない")?;
+    return Ok(());
+}
+
+#[test]
+fn interval_closed_closed() -> Result<()> {
+    let expr = "<math><mrow><mo>[</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>]</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含み d を含む")?;
+    return Ok(());
+}
+
+#[test]
+fn interval_closed_open() -> Result<()> {
+    let expr = "<math><mrow><mo>[</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>)</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含み d を含まない")?;
+    return Ok(());
+}
+
+#[test]
+fn interval_open_closed() -> Result<()> {
+    let expr = "<math><mrow><mo>(</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>]</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含まず d を含む")?;
+    return Ok(());
+}
+
 /// Verifies that an indexed cube root receives the Japanese cube-root cue.
 #[test]
 fn cube_root() -> Result<()> {
@@ -291,41 +327,5 @@ fn product_with_limits() -> Result<()> {
 fn definite_integral() -> Result<()> {
     let expr = "<math><msubsup><mo>&#x222B;</mo><mn>0</mn><mn>1</mn></msubsup><mi>x</mi><mo>&#x2146;</mo><mi>x</mi></math>";
     test("ja", "SimpleSpeak", expr, "積分 0 から, 1 まで オブ; x 微分 d x")?;
-    return Ok(());
-}
-
-/// The four bounded interval forms. English says "not including c or d"; a slot-by-slot
-/// translation would use または and change the meaning, because negation does not
-/// distribute over a Japanese disjunction. Each endpoint takes its own verb instead,
-/// with the first in the continuative form.
-#[test]
-fn interval_open_open() -> Result<()> {
-    let expr = "<math><mrow><mo>(</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>)</mo></mrow></math>";
-    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
-        "区間 c から d まで, c を含まず d を含まない")?;
-    return Ok(());
-}
-
-#[test]
-fn interval_closed_closed() -> Result<()> {
-    let expr = "<math><mrow><mo>[</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>]</mo></mrow></math>";
-    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
-        "区間 c から d まで, c を含み d を含む")?;
-    return Ok(());
-}
-
-#[test]
-fn interval_closed_open() -> Result<()> {
-    let expr = "<math><mrow><mo>[</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>)</mo></mrow></math>";
-    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
-        "区間 c から d まで, c を含み d を含まない")?;
-    return Ok(());
-}
-
-#[test]
-fn interval_open_closed() -> Result<()> {
-    let expr = "<math><mrow><mo>(</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>]</mo></mrow></math>";
-    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
-        "区間 c から d まで, c を含まず d を含む")?;
     return Ok(());
 }

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -293,3 +293,39 @@ fn definite_integral() -> Result<()> {
     test("ja", "SimpleSpeak", expr, "積分 0 から, 1 まで オブ; x 微分 d x")?;
     return Ok(());
 }
+
+/// The four bounded interval forms. English says "not including c or d"; a slot-by-slot
+/// translation would use または and change the meaning, because negation does not
+/// distribute over a Japanese disjunction. Each endpoint takes its own verb instead,
+/// with the first in the continuative form.
+#[test]
+fn interval_open_open() -> Result<()> {
+    let expr = "<math><mrow><mo>(</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>)</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含まず d を含まない")?;
+    return Ok(());
+}
+
+#[test]
+fn interval_closed_closed() -> Result<()> {
+    let expr = "<math><mrow><mo>[</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>]</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含み d を含む")?;
+    return Ok(());
+}
+
+#[test]
+fn interval_closed_open() -> Result<()> {
+    let expr = "<math><mrow><mo>[</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>)</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含み d を含まない")?;
+    return Ok(());
+}
+
+#[test]
+fn interval_open_closed() -> Result<()> {
+    let expr = "<math><mrow><mo>(</mo><mrow><mi>c</mi><mo>,</mo><mi>d</mi></mrow><mo>]</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Paren", "Interval", expr,
+        "区間 c から d まで, c を含まず d を含む")?;
+    return Ok(());
+}


### PR DESCRIPTION
Follows #726 on the `ja` branch. Thanks @moritz-gross for the `# audit-ignore` pointer on #720 — this PR is the first one that needs it, and I have measured what it does (numbers at the end).

### Why this rule cannot be translated slot by slot

`ClearSpeak-intervals` reads `(c,d)` as "the interval from c to d, not including c or d". Copying that shape into Japanese changes the meaning: English negation distributes over the disjunction, but Japanese または does not, so 「c または d を含まない」 asserts *not(c) or not(d)* rather than *neither*. The connectives and/or/but also cannot be chosen independently of polarity in Japanese.

So each endpoint now carries its own verb, joined by the continuative form:

| | now reads |
|---|---|
| `(c,d)` | 区間 c から d まで, c を含まず d を含まない |
| `[c,d]` | 区間 c から d まで, c を含み d を含む |
| `[c,d)` | 区間 c から d まで, c を含み d を含まない |
| `(c,d]` | 区間 c から d まで, c を含まず d を含む |

When one side is infinite there is only one clause, so the first verb switches to its terminal form (を含む / を含まない) instead of the continuative.

The range itself also had to move: から and まで are postpositions, so the endpoints come first, the same change as #726.

### Machine-translation fixes in the same rule

- **`コメントはありません`** — this was the bare word "not" from `then: [t: "not"]`, rendered as "there are no comments". It was spoken in every open interval.
- `含まれるもの` ("things that are included") for "including".
- `間隔から` for "the interval from". 間隔 is spacing or an interval of time, not a mathematical interval; that is 区間.

### audit-translations

Measured on this branch against a detached checkout of `ja` at 544e7fb4:

| | Rule differences | Untranslated |
|---|---|---|
| `ja` baseline | 28 | 3683 |
| this branch, no marker | 31 | 3683 |
| this branch, with `# audit-ignore` | 28 | 3674 |

So the marker cancels exactly the three intended differences.

One observation while using it, in case it is useful: `# audit-ignore` suppresses untranslated-text findings as well as rule differences (`auditor.py` lines 138 and 147), so marking this rule also hid its nine `t:` entries from the untranslated count. For a rule that diverges structurally but still needs its wording tracked, there is no way to silence only the structural half. I do not know whether that is worth a separate marker — happy to open an issue on the tool if you would like one.

I put the marker after `name:` rather than in the comment block above the rule, because `build_raw_blocks` splits on the item's first value line, so a leading `- #` comment can land in the previous rule's block.

### Deliberately not in this PR

The non-ClearSpeak `intervals` rule in `SharedRules/general.yaml` has the same から … に shape, and additionally speaks `translate(name(.),'-',' ')`, which reads the English tag name aloud in a Japanese voice. Fixing it needs interval terminology, and the obvious choice is not safe: `[a,b)` is called 右半開区間 by sources that name the open side and 左閉半開区間 by sources that name the closed side, so the same word can mean opposite things. The Japanese Wikipedia article uses the unambiguous two-sided forms 左閉右開 / 左開右閉 instead, which also map directly onto the tag names. I will send that separately.
