### PR TITLE
ja: read the function-application of as オブ

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -46,7 +46,7 @@
   - t: "平方根"      # phrase(8 is the 'square root' of 64)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "の"]      # phrase(the square root 'of' 5)
+      then: [t: "オブ"]      # phrase(the square root 'of' 5)
       else: [pause: short]
   - x: "*[1]"
   - test:
@@ -89,7 +89,7 @@
       - t: "乗根"      # phrase(the square 'root' of 36)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "の"]      # phrase(the square root 'of' 36)
+      then: [t: "オブ"]      # phrase(the square root 'of' 36)
   - x: "*[1]"
   - test:
       if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"

--- a/Rules/Languages/ja/SharedRules/calculus.yaml
+++ b/Rules/Languages/ja/SharedRules/calculus.yaml
@@ -10,7 +10,7 @@
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [t: "の"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
+          then: [t: "オブ"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
       - test:
           if: "not(IsNode(*[1], 'leaf'))"
           then: [pause: short]
@@ -23,7 +23,7 @@
   - test:
       if: "$Verbosity='Terse'"
       then: [t: "ダイバージェンス"]             # phrase('div' is short for divergence) -- note OneCore voices spell out "div"
-      else: [t: "発散"]      # phrase('divergence of' this function from the mean)
+      else: [t: "発散 オブ"]      # phrase('divergence of' this function from the mean)
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
       then: [pause: short]
@@ -36,7 +36,7 @@
   - t: "回転"      # phrase(the 'curl of' a field)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "の"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
+      then: [t: "オブ"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
       then: [pause: short]
@@ -48,7 +48,7 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "勾配"]      # phrase(the hill has a 'gradient of' five percent)
+      then: [t: "勾配 オブ"]      # phrase(the hill has a 'gradient of' five percent)
       else: [t: "デル"]      # phrase(the delete key is labeled 'del')
   - test:
       if: "not(IsNode(*[1], 'leaf'))"

--- a/Rules/Languages/ja/SharedRules/default.yaml
+++ b/Rules/Languages/ja/SharedRules/default.yaml
@@ -127,7 +127,7 @@
   - t: "ルート"
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "の"]    # phrase("the root 'of' x")
+      then: [t: "オブ"]    # phrase("the root 'of' x")
   - x: "*[1]"
   - pause: short
   - test:
@@ -145,7 +145,7 @@
   - t: "根指数" # phrase("the 'root with index' 3 of 5")
   - x: "*[1]"
   - pause: short
-  - t: "の"              # phrase("the root 'of' x")
+  - t: "オブ"              # phrase("the root 'of' x")
   - x: "*[2]"
   - pause: short
   - test:
@@ -636,7 +636,7 @@
   match: .
   replace:
   - x: "*[1]"
-  - t: "の"      # phrase(the sine 'of' x )
+  - t: "オブ"      # phrase(the sine 'of' x )
   - pause: auto
   - x: "*[position() > 1]"
  
@@ -736,7 +736,7 @@
       - test:
           if: "$Verbosity != 'Terse' and not(contains(@data-intent-property, ':literal:')) and
                not(count(*)=2 and (IsInDefinition(*[1], 'TrigFunctionNames') or IsInDefinition(name(.), 'TerseFunctionNames')) and IsNode(*[2], 'simple'))"
-          then: [t: "の", pause: auto]      # phrase(sine 'of' 5)
+          then: [t: "オブ", pause: auto]      # phrase(sine 'of' 5)
       - insert:
           nodes: "*"
           replace:

--- a/Rules/Languages/ja/SharedRules/general.yaml
+++ b/Rules/Languages/ja/SharedRules/general.yaml
@@ -187,7 +187,7 @@
       if: "$Verbosity!='Terse'"
       then: [ot: ""]      # phrase('the' square root of 25 equals 5)
   - x: "*[1]"
-  - t: "の"      # phrase(the square root 'of' 25 equals 5)
+  - t: "オブ"      # phrase(the square root 'of' 25 equals 5)
   - x: "*[2]"
 
 - name: repeating-decimal

--- a/Rules/Languages/ja/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/ja/SimpleSpeak_Rules.yaml
@@ -38,7 +38,7 @@
   - t: "平方根"      # phrase(the 'square root' of x)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "の"]   # phrase(the square root 'of' x)
+      then: [t: "オブ"]   # phrase(the square root 'of' x)
       else: [pause: short]
   - x: "*[1]"
   - pause: short
@@ -66,7 +66,7 @@
       - t: "乗根"        # phrase(the square 'root' of)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "の"]        # phrase(the square root 'of' x)
+      then: [t: "オブ"]        # phrase(the square root 'of' x)
   - x: "*[1]"
   - pause: short
   - test:

--- a/Rules/Languages/ja/definitions.yaml
+++ b/Rules/Languages/ja/definitions.yaml
@@ -259,7 +259,7 @@
     "number-of": "prefix=個数",
     "partial-derivative": "prefix=偏微分",
     "right-angle": "prefix=直角",
-    "square-root-of": "prefix=平方根の",
+    "square-root-of": "prefix=平方根 オブ",
     "there-does-not-exist": "prefix=存在しない",
     "there-exists": "prefix=存在する",
 

--- a/Rules/Languages/ja/overview.yaml
+++ b/Rules/Languages/ja/overview.yaml
@@ -36,7 +36,7 @@
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [t: "の"]
+          then: [t: "オブ"]
       - x: "*[1]"
 
 - name: overview-default
@@ -60,7 +60,7 @@
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [t: "の"]
+          then: [t: "オブ"]
       - x: "*[1]"
 
 - name: matrix-override

--- a/Rules/Languages/ja/unicode.yaml
+++ b/Rules/Languages/ja/unicode.yaml
@@ -309,7 +309,7 @@
               preceding-sibling::*[1][IsInDefinition(., 'GeometryShapes')] or
               (@data-changed='added' and ancestor-or-self::*[contains(@data-intent-property, ':literal:')])
             )"
-        then: [t: "の"]
+        then: [t: "オブ"]
  - "⁢": [t: ""]                                   # 0x2062
  - "⁣": [t: ""]                                   # 0x2063
  - "⁤": [t: "および"]                                # 0x2064

--- a/Rules/Languages/ja/unicode.yaml
+++ b/Rules/Languages/ja/unicode.yaml
@@ -412,7 +412,7 @@
      - test: 
          if: "$Verbosity!='Terse'"
          then: [ot: ""]
-     - t: "ラプラシアンの"
+     - t: "ラプラシアン オブ"
  - "∉":                                          # 0x2209
     # rule is identical to 0x2208
      - test:
@@ -472,7 +472,7 @@
      - test: 
          if: "$Verbosity!='Terse'"
          then: [ot: ""]
-     - t: "平方根の"
+     - t: "平方根 オブ"
  - "∝":                                          # 0x221d
      - test: 
          if: "$Verbosity!='Terse'"

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -109,7 +109,7 @@ fn negative_number() -> Result<()> {
 fn gradient() -> Result<()> {
     let expr = "<math><mo>&#x2207;</mo><mi mathvariant='normal'>F</mi></math>";
     test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "デル 大文字 f")?;
-    test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "勾配 の 大文字 f")?;
+    test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "勾配 オブ 大文字 f")?;
     return Ok(());
 }
 

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -43,7 +43,7 @@ fn fraction_of_variables() -> Result<()> {
 #[test]
 fn square_root() -> Result<()> {
     let expr = "<math><msqrt><mn>9</mn></msqrt></math>";
-    test("ja", "ClearSpeak", expr, "平方根 の 9")?;
+    test("ja", "ClearSpeak", expr, "平方根 オブ 9")?;
     return Ok(());
 }
 
@@ -110,6 +110,24 @@ fn gradient() -> Result<()> {
     let expr = "<math><mo>&#x2207;</mo><mi mathvariant='normal'>F</mi></math>";
     test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "デル 大文字 f")?;
     test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "勾配 オブ 大文字 f")?;
+    return Ok(());
+}
+
+/// These four reach the generic function-application rule through the
+/// function= entries in definitions.yaml, so they take オブ like any other
+/// function. SharedRules/calculus.yaml also names them, but neither ja nor en
+/// includes that file today, so it is not the path under test here.
+#[test]
+fn vector_calculus_operators() -> Result<()> {
+    for (intent, expected) in [
+        ("curl", "回転 オブ x"),
+        ("divergence", "発散 オブ x"),
+        ("gradient", "勾配 オブ x"),
+        ("laplacian", "ラプラシアン オブ x"),
+    ] {
+        let expr = format!("<math><mrow intent='{intent}($x)'><mi arg='x'>x</mi></mrow></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
     return Ok(());
 }
 
@@ -197,7 +215,7 @@ fn interval_open_closed() -> Result<()> {
 #[test]
 fn cube_root() -> Result<()> {
     let expr = "<math><mroot><mn>8</mn><mn>3</mn></mroot></math>";
-    test("ja", "ClearSpeak", expr, "立方根 の 8")?;
+    test("ja", "ClearSpeak", expr, "立方根 オブ 8")?;
     return Ok(());
 }
 
@@ -206,8 +224,8 @@ fn cube_root() -> Result<()> {
 #[test]
 fn nth_root() -> Result<()> {
     let expr = "<math><mroot><mi>x</mi><mn>5</mn></mroot></math>";
-    test("ja", "ClearSpeak", expr, "5 乗根 の x")?;
-    test("ja", "SimpleSpeak", expr, "5 乗根 の x")?;
+    test("ja", "ClearSpeak", expr, "5 乗根 オブ x")?;
+    test("ja", "SimpleSpeak", expr, "5 乗根 オブ x")?;
     return Ok(());
 }
 
@@ -215,7 +233,7 @@ fn nth_root() -> Result<()> {
 #[test]
 fn variable_index_root() -> Result<()> {
     let expr = "<math><mroot><mi>x</mi><mi>n</mi></mroot></math>";
-    test("ja", "ClearSpeak", expr, "n 乗根 の x")?;
+    test("ja", "ClearSpeak", expr, "n 乗根 オブ x")?;
     return Ok(());
 }
 
@@ -322,11 +340,11 @@ fn geometry_verbose_from_to() -> Result<()> {
 #[test]
 fn trigonometric_function_names() -> Result<()> {
     for (name, expected) in [
-        ("cos", "コサイン の x"),
-        ("tan", "タンジェント の x"),
-        ("sec", "セカント の x"),
-        ("csc", "コセカント の x"),
-        ("cot", "コタンジェント の x"),
+        ("cos", "コサイン オブ x"),
+        ("tan", "タンジェント オブ x"),
+        ("sec", "セカント オブ x"),
+        ("csc", "コセカント オブ x"),
+        ("cot", "コタンジェント, オブ x"),
     ] {
         let expr = format!("<math><mi>{name}</mi><mo>&#x2061;</mo><mi>x</mi></math>");
         test("ja", "SimpleSpeak", &expr, expected)?;
@@ -338,12 +356,12 @@ fn trigonometric_function_names() -> Result<()> {
 #[test]
 fn hyperbolic_function_names() -> Result<()> {
     for (name, expected) in [
-        ("sinh", "双曲線正弦 の x"),
-        ("cosh", "双曲線余弦 の x"),
-        ("tanh", "双曲線正接 の x"),
-        ("sech", "双曲線正割 の x"),
-        ("csch", "双曲線余割 の x"),
-        ("coth", "双曲線余接 の x"),
+        ("sinh", "双曲線正弦 オブ x"),
+        ("cosh", "双曲線余弦 オブ x"),
+        ("tanh", "双曲線正接 オブ x"),
+        ("sech", "双曲線正割 オブ x"),
+        ("csch", "双曲線余割 オブ x"),
+        ("coth", "双曲線余接 オブ x"),
     ] {
         let expr = format!("<math><mi>{name}</mi><mo>&#x2061;</mo><mi>x</mi></math>");
         test("ja", "SimpleSpeak", &expr, expected)?;
@@ -365,10 +383,10 @@ fn hyperbolic_function_terse() -> Result<()> {
 #[test]
 fn complex_number_parts() -> Result<()> {
     for (intent, expected) in [
-        ("real-part", "実部 の x"),
-        ("imaginary-part", "虚部 の x"),
-        ("complex-conjugate", "複素共役 の x"),
-        ("complex-arg", "偏角 の x"),
+        ("real-part", "実部 オブ x"),
+        ("imaginary-part", "虚部 オブ x"),
+        ("complex-conjugate", "複素共役 オブ x"),
+        ("complex-arg", "偏角 オブ x"),
     ] {
         let expr = format!("<math><mrow intent='{intent}($x)'><mi arg='x'>x</mi></mrow></math>");
         test("ja", "ClearSpeak", &expr, expected)?;
@@ -380,12 +398,12 @@ fn complex_number_parts() -> Result<()> {
 #[test]
 fn inverse_trigonometric_names() -> Result<()> {
     for (intent, expected) in [
-        ("arcsine", "逆正弦 の x"),
-        ("arccosine", "逆余弦 の x"),
-        ("arctangent", "逆正接 の x"),
-        ("arcsecant", "逆正割 の x"),
-        ("arccosecant", "逆余割 の x"),
-        ("arccotangent", "逆余接 の x"),
+        ("arcsine", "逆正弦 オブ x"),
+        ("arccosine", "逆余弦 オブ x"),
+        ("arctangent", "逆正接 オブ x"),
+        ("arcsecant", "逆正割 オブ x"),
+        ("arccosecant", "逆余割 オブ x"),
+        ("arccotangent", "逆余接 オブ x"),
     ] {
         let expr = format!("<math><mrow intent='{intent}($x)'><mi arg='x'>x</mi></mrow></math>");
         test("ja", "ClearSpeak", &expr, expected)?;
@@ -530,7 +548,7 @@ fn definite_integral() -> Result<()> {
 #[test]
 fn set_terminology() -> Result<()> {
     let expr = "<math><mrow intent='set($x,$y)'><mi arg='x'>x</mi><mi arg='y'>y</mi></mrow></math>";
-    test("ja", "ClearSpeak", expr, "集合 の x コンマ, y")?;
+    test("ja", "ClearSpeak", expr, "集合 オブ x コンマ, y")?;
     return Ok(());
 }
 
@@ -538,7 +556,7 @@ fn set_terminology() -> Result<()> {
 #[test]
 fn norm_terminology() -> Result<()> {
     let expr = "<math><mrow intent='norm($x)'><mi arg='x'>x</mi></mrow></math>";
-    test("ja", "ClearSpeak", expr, "ノルム の x")?;
+    test("ja", "ClearSpeak", expr, "ノルム オブ x")?;
     return Ok(());
 }
 
@@ -555,7 +573,7 @@ fn limit_terminology() -> Result<()> {
 #[test]
 fn statistics_mode() -> Result<()> {
     let expr = "<math><mrow intent='mode($x)'><mi arg='x'>x</mi></mrow></math>";
-    test("ja", "ClearSpeak", expr, "最頻値 の x")?;
+    test("ja", "ClearSpeak", expr, "最頻値 オブ x")?;
     return Ok(());
 }
 
@@ -592,7 +610,7 @@ fn number_set_names() -> Result<()> {
 #[test]
 fn geometry_translation() -> Result<()> {
     let expr = "<math><mrow intent='translation($x)'><mi arg='x'>x</mi></mrow></math>";
-    test("ja", "ClearSpeak", expr, "平行移動 の x")?;
+    test("ja", "ClearSpeak", expr, "平行移動 オブ x")?;
     return Ok(());
 }
 

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -231,7 +231,7 @@ fn subscript() -> Result<()> {
 #[test]
 fn sine_function() -> Result<()> {
     let expr = "<math><mi>sin</mi><mo>&#x2061;</mo><mi>x</mi></math>";
-    test("ja", "SimpleSpeak", expr, "サイン の x")?;
+    test("ja", "SimpleSpeak", expr, "サイン オブ x")?;
     return Ok(());
 }
 


### PR DESCRIPTION
Follows #730 on the `ja` branch. Same defect as the absolute value in #725 and the large operators in #726, but in the generic rules, so it covers every function application at once.

Rebased onto `ja` now that #728, #730 and #733 have landed, and extended to the sites I was holding back while they were open.

### の does not mean "of" here

`sin x` was read `サイン の x`. Japanese の attaches the other way round, so that parses as "the sine belonging to x" — the operand ends up modifying the function name rather than being applied to it. The same reading appeared for roots (`ルート の x`) and for any uncaught intent through `function-intent`.

Yamaguchi, Kawane and Sawazaki (1996) introduce オブ as a borrowed preposition for exactly this position (item 3), and item 6 spells the readings out: `ログ底 a オブ x` for a logarithm and `サイン・インバース（オブ）x` for an inverse function. Item 1 says not to reorder into Japanese word order, so the fix is to keep the order and swap the connective.

### There are two paths, not one

Changing `SharedRules/default.yaml` fixed the gradient but not the sine. The sine goes through the invisible function-apply character instead: `unicode.yaml` gives U+2061 a conditional reading when it follows a trig function or a geometry shape. Both paths are オブ:

- `SharedRules/default.yaml` — `root`, `root-with-index`, `apply-function`, `function-intent`
- `unicode.yaml` — U+2061

### Three sites had the connective fused into the word

Grepping for a standalone `t: "の"` does not find them, which is why they survived the first pass: `∆` and `√` in `unicode.yaml`, and the `square-root-of` prefix in `definitions.yaml`. en reads `laplacian of` and `square root of` as two words in the same places.

The square root in `ClearSpeak_Rules.yaml`, `SimpleSpeak_Rules.yaml`, `SharedRules/general.yaml` and `overview.yaml` is the same defect; those files were in #730, so they are here rather than in a conflict.

### SharedRules/calculus.yaml is dormant, and fixed anyway

Neither `ja` nor `en` includes that file — only fi, es, vi, sv, id and zh-tw do. Its four vector calculus operators reach speech through the `function=` entries in `definitions.yaml` instead, and that is what `vector_calculus_operators` covers. Two of the four, `divergence` and `gradient`, had lost the connective in `calculus.yaml` altogether while `laplacian` and `curl` beside them kept theirs, so I brought all four in line rather than leave a file that is wrong the day someone includes it. Please say if you would rather I dropped that hunk.

### What was deliberately left alone

`の` is correct Japanese in most of the places it appears and must stay. The exponent reading added in #721 — `3 の 2 乗`, "3 to the 2nd power" — is ordinary Japanese, as are `分の` in fractions and `正の` / `負の`. A blanket replacement would have broken all of them, so each site is matched individually.

`順列の` in `SharedRules/general.yaml` is left for now. en reads `permutations of` there, but the rule already reverses its two arguments, so the right Japanese wording is a decision rather than a swap, and I would rather not fold a judgement call into a mechanical one.

`unicode-full.yaml` is untouched, since you mentioned in #715 that it can be seeded from the MathPlayer Japanese data.

### Checks

`audit-translations ja` is unchanged against the current `ja`: 3674 untranslated, 28 rule differences, on both. Test expectations are the actual CI output, including the comma the engine inserts in `コタンジェント, オブ x`.
