### PR TITLE
ja: use the Japanese names for the elementary functions and the parts of a complex number

### DIFF
--- a/Rules/Languages/ja/SharedRules/general.yaml
+++ b/Rules/Languages/ja/SharedRules/general.yaml
@@ -73,14 +73,14 @@
   match: "count(*)=0"
   replace:
   - bookmark: "@id"
-  - t: "実際の部分"      # phrase('the real part' of a complex number does not include the imaginary part)
+  - t: "実部"      # phrase('the real part' of a complex number does not include the imaginary part)
 
 - name: imaginary-part
   tag: imaginary-part
   match: "count(*)=0"
   replace:
   - bookmark: "@id"
-  - t: "想像上の部分"      # phrase('the imaginary part' is part of a complex number)
+  - t: "虚部"      # phrase('the imaginary part' is part of a complex number)
 
 # rules on scripted vertical bars ('evaluated at')
 - name: evaluated-at-2
@@ -361,8 +361,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "タン"]      # phrase(the 'tan' is the ratio of the opposite to the adjacent side of a right-angled triangle)
-      else: [t: "接線"]      # phrase(a 'tangent' is a straight line that touches a curve)
+      then: [t: "タンジェント"]      # phrase(the 'tan' is the ratio of the opposite to the adjacent side of a right-angled triangle)
+      else: [t: "タンジェント"]      # phrase(a 'tangent' is a straight line that touches a curve)
 - name: sec
   tag: mi
   match: ".='sec'"
@@ -370,8 +370,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "探す"]      # phrase(to 'seek' a solution)
-      else: [t: "割線"]      # phrase(a 'secant' intersects a curve at two or more points)
+      then: [t: "セカント"]      # phrase(to 'seek' a solution)
+      else: [t: "セカント"]      # phrase(a 'secant' intersects a curve at two or more points)
 - name: csc
   tag: mi
   match: ".='csc'"
@@ -379,7 +379,7 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "コセック"]      # phrase(we will 'cosecant' a solution)
+      then: [t: "コセカント"]      # phrase(we will 'cosecant' a solution)
       else: [t: "コセカント"]      # phrase(the 'cosecant' is the reciprocal of the secant)
 - name: cot
   tag: mi
@@ -388,8 +388,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "コタン"]      # phrase(find the 'cotangent' in a right-angle triangle)
-      else: [t: "余接"]      # phrase(the 'cotangent' is the reciprocal of the tangent)
+      then: [t: "コタンジェント"]      # phrase(find the 'cotangent' in a right-angle triangle)
+      else: [t: "コタンジェント"]      # phrase(the 'cotangent' is the reciprocal of the tangent)
 
 - name: sinh
   tag: mi
@@ -398,8 +398,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "ピンチ"]      # phrase(the word 'sinch' is an abbreviation for hyperbolic sine)
-      else: [t: "高分子正弦"]      # phrase(the 'hyperbolic sine' is used in mathematics)
+      then: [t: "ハイパーボリックサイン"]      # phrase(the word 'sinch' is an abbreviation for hyperbolic sine)
+      else: [t: "双曲線正弦"]      # phrase(the 'hyperbolic sine' is used in mathematics)
 - name: cosh
   tag: mi
   match: ".='cosh'"
@@ -407,8 +407,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "コッシュ"]      # phrase('cosh' is an abbreviation of hyperbolic cosine)
-      else: [t: "高分子コサイン"]      # phrase(the 'hyperbolic cosine' is a mathematical function)
+      then: [t: "ハイパーボリックコサイン"]      # phrase('cosh' is an abbreviation of hyperbolic cosine)
+      else: [t: "双曲線余弦"]      # phrase(the 'hyperbolic cosine' is a mathematical function)
 - name: tanh
   tag: mi
   match: ".='tanh'"
@@ -416,8 +416,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "タンチ"]      # phrase('tanch' is shorthand for hyperbolic tangent)
-      else: [t: "双曲線の正接"]      # phrase('hyperbolic tangent' is a mathematical function)
+      then: [t: "ハイパーボリックタンジェント"]      # phrase('tanch' is shorthand for hyperbolic tangent)
+      else: [t: "双曲線正接"]      # phrase('hyperbolic tangent' is a mathematical function)
 - name: sech
   tag: mi
   match: ".='sech'"
@@ -425,8 +425,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "シーメール"]      # phrase('sheck' is shorthand for hyperbolic secant)
-      else: [t: "ハイパーボリック 正割"]      # phrase('hyperbolic secant' is a mathematical function)
+      then: [t: "ハイパーボリックセカント"]      # phrase('sheck' is shorthand for hyperbolic secant)
+      else: [t: "双曲線正割"]      # phrase('hyperbolic secant' is a mathematical function)
 - name: csch
   tag: mi
   match: ".='csch'"
@@ -434,8 +434,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "コシュネック"]      # phrase('cosheck' is shorthand for hyperbolic cosecant)
-      else: [t: "ハイパーボリック・コンセカント"]      # phrase('hyperbolic cosecant' is a mathematical function)
+      then: [t: "ハイパーボリックコセカント"]      # phrase('cosheck' is shorthand for hyperbolic cosecant)
+      else: [t: "双曲線余割"]      # phrase('hyperbolic cosecant' is a mathematical function)
 - name: coth
   tag: mi
   match: ".='coth'"
@@ -443,8 +443,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "コタンチ"]      # phrase('cotanch' is shorthand for hyperbolic cotangent)
-      else: [t: "ハイパーボリックコタント"]      # phrase(the 'hyperbolic cotangent' is a mathematical function)
+      then: [t: "ハイパーボリックコタンジェント"]      # phrase('cotanch' is shorthand for hyperbolic cotangent)
+      else: [t: "双曲線余接"]      # phrase(the 'hyperbolic cotangent' is a mathematical function)
 - name: exponential
   tag: mi
   match: ".='exp'"

--- a/Rules/Languages/ja/definitions.yaml
+++ b/Rules/Languages/ja/definitions.yaml
@@ -93,19 +93,19 @@
     "least-common-multiple":"function=エルシーエム:エルシーエム:最小公倍数", # In webpage typo "lest common"
 
     "absolute-value": "function=;絶対値:絶対値:絶対値;絶対値",
-    "complex-conjugate":"function=複雑なコンジュゲート",
-    "complex-arg":"function=アーグ",
-    "real-part": "function=実際の部分",
-    "imaginary-part": "function=想像上の部分:想像上の部分:想像上の部分",
+    "complex-conjugate":"function=複素共役",
+    "complex-arg":"function=偏角",
+    "real-part": "function=実部",
+    "imaginary-part": "function=虚部",
 
-    "polar-coordinate":"function=極の座標",
+    "polar-coordinate":"function=極座標",
     "spherical-coordinate":"function=球面座標",
     "cartesian-coordinate":"function=デカルト座標",
     "coordinate":"function=座標",
     "floor":"function=床関数",
     "ceiling":"function=天井関数",
     "round":"function=ラウンド値",
-    "fractional-part":"function=フラクショナルパーツ",
+    "fractional-part":"function=小数部分",
 
 
     ### Calculus
@@ -136,28 +136,28 @@
 
     ### Elementary classical functions
     "sine":"function=サイン: 正弦",
-    "cosine":"function=コス:コサイン",
-    "tangent":"function=タン: タンジェント",
-    "secant":"function=種目: 正割",
+    "cosine":"function=コサイン: 余弦",
+    "tangent":"function=タンジェント: 正接",
+    "secant":"function=セカント: 正割",
     "cosecant":"function=コセカント: 余割",
-    "cotangent":"function=コタン:コタント",
+    "cotangent":"function=コタンジェント: 余接",
 
-    "arcsine":"function=アークシネ",
-    "arccosine":"function=アルコシン",
-    "arctangent":"function=アークタンジェント",
-    "arcsecant":"function=アークセカント",
-    "arccosecant":"function=アークコンセカント",
-    "arccotangent":"function=アーク-コタント",
+    "arcsine":"function=アークサイン: 逆正弦",
+    "arccosine":"function=アークコサイン: 逆余弦",
+    "arctangent":"function=アークタンジェント: 逆正接",
+    "arcsecant":"function=アークセカント: 逆正割",
+    "arccosecant":"function=アークコセカント: 逆余割",
+    "arccotangent":"function=アークコタンジェント: 逆余接",
 
     "hyperbolic-sine":"function=ハイパーボリックサイン: 双曲線正弦",
-    "hyperbolic-cosine":"function=コッシュ",
-    "hyperbolic-tangent":"function=タンチ",
+    "hyperbolic-cosine":"function=ハイパーボリックコサイン: 双曲線余弦",
+    "hyperbolic-tangent":"function=ハイパーボリックタンジェント: 双曲線正接",
     "hyperbolic-secant":"function=ハイパーボリックセカント: 双曲線正割",
     "hyperbolic-cosecant":"function=ハイパーボリックコセカント: 双曲線余割",
     "hyperbolic-cotangent":"function=ハイパーボリックコタンジェント: 双曲線余接",
 
     "arc-hyperbolic-sine":"function=アークハイパーボリックサイン",
-    "arc-hyperbolic-cosine":"function=アークコッシュ",
+    "arc-hyperbolic-cosine":"function=アークハイパーボリックコサイン",
     "arc-hyperbolic-tangent":"function=アークハイパーボリックタンジェント",
     "arc-hyperbolic-secant":"function=アークハイパーボリックセカント",
     "arc-hyperbolic-cosecant":"function=アークハイパーボリックコセカント",

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -246,6 +246,83 @@ fn geometry_verbose_from_to() -> Result<()> {
     return Ok(());
 }
 
+/// The trigonometric functions have settled Japanese names. 接線 and 割線 are the
+/// tangent *line* and the secant *line* -- curves, not the functions -- and 探す is
+/// the verb "to search", so none of them can be spoken for tan/sec.
+#[test]
+fn trigonometric_function_names() -> Result<()> {
+    for (name, expected) in [
+        ("cos", "コサイン の x"),
+        ("tan", "タンジェント の x"),
+        ("sec", "セカント の x"),
+        ("csc", "コセカント の x"),
+        ("cot", "コタンジェント の x"),
+    ] {
+        let expr = format!("<math><mi>{name}</mi><mo>&#x2061;</mo><mi>x</mi></math>");
+        test("ja", "SimpleSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// The six hyperbolic functions are 双曲線正弦 through 双曲線余接.
+#[test]
+fn hyperbolic_function_names() -> Result<()> {
+    for (name, expected) in [
+        ("sinh", "双曲線正弦 の x"),
+        ("cosh", "双曲線余弦 の x"),
+        ("tanh", "双曲線正接 の x"),
+        ("sech", "双曲線正割 の x"),
+        ("csch", "双曲線余割 の x"),
+        ("coth", "双曲線余接 の x"),
+    ] {
+        let expr = format!("<math><mi>{name}</mi><mo>&#x2061;</mo><mi>x</mi></math>");
+        test("ja", "SimpleSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// Terse reads the abbreviation aloud instead of the formal name.
+#[test]
+fn hyperbolic_function_terse() -> Result<()> {
+    let expr = "<math><mi>tanh</mi><mo>&#x2061;</mo><mi>x</mi></math>";
+    test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "ハイパーボリックタンジェント, x")?;
+    return Ok(());
+}
+
+/// The parts of a complex number are 実部 and 虚部, and its conjugate is 複素共役.
+/// 実際の部分 ("the actual portion") and 想像上の部分 ("an imagined portion") are
+/// the everyday senses of "real" and "imaginary", not the mathematical ones.
+#[test]
+fn complex_number_parts() -> Result<()> {
+    for (intent, expected) in [
+        ("real-part", "実部 の x"),
+        ("imaginary-part", "虚部 の x"),
+        ("complex-conjugate", "複素共役 の x"),
+        ("complex-arg", "偏角 の x"),
+    ] {
+        let expr = format!("<math><mrow intent='{intent}($x)'><mi arg='x'>x</mi></mrow></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// The inverse trigonometric functions are 逆正弦 through 逆余接.
+#[test]
+fn inverse_trigonometric_names() -> Result<()> {
+    for (intent, expected) in [
+        ("arcsine", "逆正弦 の x"),
+        ("arccosine", "逆余弦 の x"),
+        ("arctangent", "逆正接 の x"),
+        ("arcsecant", "逆正割 の x"),
+        ("arccosecant", "逆余割 の x"),
+        ("arccotangent", "逆余接 の x"),
+    ] {
+        let expr = format!("<math><mrow intent='{intent}($x)'><mi arg='x'>x</mi></mrow></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
 /// Verifies that common lowercase Greek letters use their Japanese names.
 #[test]
 fn greek_letters() -> Result<()> {


### PR DESCRIPTION
The Japanese seed data reached the elementary functions and the complex-number
parts through machine translation, and most of the names came out as either a
different mathematical object or an ordinary Japanese word. This replaces them
with the terms Japanese mathematics actually uses.

Only strings change. No rule is added, removed, or restructured, and
`audit-translations ja` reports the same 28 rule differences before and after.

### Names that were a different object

| symbol | was | means | now |
| --- | --- | --- | --- |
| `tan` | 接線 | the tangent **line** (a curve) | タンジェント |
| `sec` | 割線 | the secant **line** (a curve) | セカント |
| `sec` (terse) | 探す | the verb "to search" | セカント |
| `sinh` | 高分子正弦 | 高分子 is a *macromolecule* | 双曲線正弦 |
| `cosh` | 高分子コサイン | same | 双曲線余弦 |
| `real-part` | 実際の部分 | "the actual portion" | 実部 |
| `imaginary-part` | 想像上の部分 | "a portion someone imagined" | 虚部 |
| `complex-conjugate` | 複雑なコンジュゲート | 複雑な is "complicated" | 複素共役 |
| `polar-coordinate` | 極の座標 | "coordinate belonging to a pole" | 極座標 |

### Names that were not Japanese words at all

`種目` (secant), `アークシネ` (arcsine), `アルコシン` (arccosine),
`アーク-コタント` (arccotangent), `コタント` (cotangent),
`ピンチ` (sinh, terse), `タンチ` (tanh), `コシュネック` (csch),
`コタンチ` (coth), `シーメール` (sech, terse — this one is an offensive word in
Japanese), `フラクショナルパーツ` (fractional part), `アーグ` (complex arg).

### Terms used

All of them are the standard Japanese names and are the ones the Japanese
Wikipedia articles use:

- trigonometric: 正弦 / 余弦 / 正接 / 正割 / 余割 / 余接
- inverse trigonometric: 逆正弦 … 逆余接 (all six appear in 逆三角関数)
- hyperbolic: 双曲線正弦 … 双曲線余接 (all six appear in 双曲線関数)
- complex numbers: 実部, 虚部, 複素共役 (共役複素数 redirects to it), 偏角

The inverse **hyperbolic** functions keep katakana only. Japanese sources do not
use a 逆双曲線正弦 form, so there was nothing to put there; the change is limited
to spelling `アークコッシュ` as `アークハイパーボリックコサイン`.

### Verbosity

`definitions.yaml` already used `katakana: kanji` for `sine`, `cosecant` and the
hyperbolic entries, so the rest of the block now follows it: terse says the
abbreviation the way it is read aloud (コサイン, タンジェント), medium and verbose
say the formal name (余弦, 正接).

The `mi` rules in `general.yaml` keep katakana in both branches, matching the
`cos` rule that was already there and `sin`, which — as in `en` — has no
verbosity test and always says サイン. Splitting only some of the six would make
one formula say サイン and 余弦 side by side.

### Tests

22 assertions in `tests/Languages/ja/ja.rs`: the six trigonometric and six
hyperbolic functions as `mi`, one terse reading, the four complex-number
intents, and the six inverse trigonometric intents.
