### PR TITLE
ja: name the accents and fix two symbols read as unrelated words

### DIFF
--- a/Rules/Languages/ja/unicode.yaml
+++ b/Rules/Languages/ja/unicode.yaml
@@ -166,10 +166,10 @@
  - "^":                                           # 0x5e
     - test:
         if: "parent::m:modified-variable or parent::m:mover"
-        then: [t: "帽子帽子"]
-        else: [t: "ケアト"]
+        then: [t: "ハット"]
+        else: [t: "キャレット"]
  - "_": [t: "アンダーバー"]                          # 0x5f
- - "`": [t: "墓地"]                              # 0x60
+ - "`": [t: "グレイヴアクセント"]                              # 0x60
  - "{":                                         # 0x7b
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
@@ -205,7 +205,7 @@
         then: [t: "中括弧閉じ"]
         else: [t: "右中括弧"]                            
 
- - "~": [t: "チルド"]                               # 0x7e
+ - "~": [t: "チルダ"]                               # 0x7e
  - " ":                                            # 0xa0
     - test:
         # could be mtext in mtd or mtext in an mrow that is a concatenation of mtd's. Is there a better solution?
@@ -213,10 +213,10 @@
         then: [t: "空"]                         # want to say something for fraction (etc) with empty child
         else: [t: ""]                            
 
- - "¬": [t: "コメントはありません"]                                 # 0xac
- - "°": [t: "キーワード"]                           # 0xb0
+ - "¬": [t: "ノット"]                                 # 0xac
+ - "°": [t: "度"]                           # 0xb0
  - "±": [t: "プラスまたはマイナス"]                       # 0xb1
- - "´": [t: "アキュート"]                            # 0xb4
+ - "´": [t: "アキュートアクセント"]                            # 0xb4
  - "·":                                            # 0xB7
     - test:
         if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')] or not($SpeechStyle = 'ClearSpeak' and $ClearSpeak_MultSymbolDot = 'Auto')"
@@ -237,14 +237,14 @@
             else: [t: "掛ける"]
 
  - "÷": [t: "割る"]                          # 0xf7
- - "̀": [t: "砂利アクセント装飾"]          # 0x300
- - "́": [t: "アキュート アクセントの装飾"]          # 0x301
- - "̂": [t: "円滑なアクセントの装飾"]     # 0x302
- - "̃": [t: "チルド装飾"]                 # 0x303
+ - "̀": [t: "グレイヴアクセント装飾"]          # 0x300
+ - "́": [t: "アキュートアクセント装飾"]          # 0x301
+ - "̂": [t: "サーカムフレックス装飾"]     # 0x302
+ - "̃": [t: "チルダ装飾"]                 # 0x303
  - "̄": [t: "マクロン装飾"]                # 0x304
  - "̅": [t: "オーバーバー装飾"]               # 0x305
- - "̆": [t: "ブリーブ"]                               # 0x306
- - "̇": [t: "装飾上の点"]             # 0x307
+ - "̆": [t: "ブレーヴェ"]                               # 0x306
+ - "̇": [t: "上付きドット装飾"]             # 0x307
 
    # Note: ClearSpeak has pref TriangleSymbol for "Δ", but that is wrong
  - "Α-Ω": 

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -207,6 +207,40 @@ fn less_than() -> Result<()> {
     return Ok(());
 }
 
+/// A hat over a variable is ハット. 帽子 is the thing you wear, and it was said
+/// twice.
+#[test]
+fn accent_hat() -> Result<()> {
+    let expr = "<math><mover><mi>x</mi><mo>^</mo></mover></math>";
+    test("ja", "ClearSpeak", expr, "x ハット")?;
+    return Ok(());
+}
+
+/// A tilde is チルダ. チルド is the loanword for "chilled" (as in chilled food).
+#[test]
+fn accent_tilde() -> Result<()> {
+    let expr = "<math><mover><mi>x</mi><mo>~</mo></mover></math>";
+    test("ja", "ClearSpeak", expr, "x チルダ")?;
+    return Ok(());
+}
+
+/// The degree sign is 度. キーワード ("keyword") is not a unit of angle.
+#[test]
+fn degree_sign() -> Result<()> {
+    let expr = "<math><mn>90</mn><mo>&#xb0;</mo></math>";
+    test("ja", "ClearSpeak", expr, "90 度")?;
+    return Ok(());
+}
+
+/// The negation sign is ノット. The seed said コメントはありません -- "there are no
+/// comments" -- because the English source word is "not".
+#[test]
+fn logical_not() -> Result<()> {
+    let expr = "<math><mo>&#xac;</mo><mi>p</mi></math>";
+    test("ja", "ClearSpeak", expr, "ノット p")?;
+    return Ok(());
+}
+
 /// Geometry has settled Japanese terms: 線分, 半直線, 弧, 点. The katakana
 /// transliterations of the English words are not used for these.
 #[test]


### PR DESCRIPTION
The accents in `unicode.yaml` were machine-translated through the everyday sense
of the English source word rather than the typographic one, so most of them name
something unrelated. Two nearby symbols have the same defect and are fixed here
as well.

Only strings in `Rules/Languages/ja/unicode.yaml` change. No rule is added,
removed, or restructured, and `audit-translations ja` reports the same 28 rule
differences as `ja` does.

### What each one says today

| char | English source | Japanese was | which means | now |
| --- | --- | --- | --- | --- |
| `¬` 0xac | not | コメントはありません | "there are no comments" | ノット |
| `°` 0xb0 | degrees | キーワード | "keyword" | 度 |
| `` ` `` 0x60 | grave | 墓地 | a graveyard | グレイヴアクセント |
| `̀` 0x300 | grave accent | 砂利アクセント装飾 | 砂利 is gravel | グレイヴアクセント装飾 |
| `̂` 0x302 | circumflex accent | 円滑なアクセントの装飾 | "a smooth accent" | サーカムフレックス装飾 |
| `^` 0x5e (over) | hat | 帽子帽子 | the hat you wear, said twice | ハット |
| `^` 0x5e (bare) | caret | ケアト | not a word | キャレット |
| `~` 0x7e | tilde | チルド | the loanword for *chilled* | チルダ |
| `̃` 0x303 | tilde | チルド装飾 | same | チルダ装飾 |
| `̆` 0x306 | breve | ブリーブ | not a word | ブレーヴェ |
| `̇` 0x307 | dot above | 装飾上の点 | "a dot on top of the embellishment" | 上付きドット装飾 |
| `´` 0xb4 | acute | アキュート | fine, but inconsistent with 0x301 | アキュートアクセント |
| `́` 0x301 | acute accent | アキュート アクセントの装飾 | stray space | アキュートアクセント装飾 |

`¬` and `°` matter most: negation and angle are read in ordinary school
mathematics, and neither sentence was intelligible.

### Names used

These are the article titles the Japanese Wikipedia uses for the marks:
サーカムフレックス (曲折アクセント redirects to it), グレイヴ・アクセント
(アクサングラーブ redirects to it), アキュート・アクセント, チルダ, ブレーヴェ,
キャレット. ハット is how a hatted variable is read aloud in Japanese
(x̂ is "エックス ハット").

0x304 マクロン and 0x305 オーバーバー were already right and are untouched.

### Tests

Four assertions in `tests/Languages/ja/ja.rs`: the hat and tilde accents over a
variable, the degree sign after a number, and the negation sign before a
variable.
