### PR TITLE
ja: fix the symbol readings, including the variable a being read as an eagle

### DIFF
--- a/Rules/Languages/ja/SharedRules/general.yaml
+++ b/Rules/Languages/ja/SharedRules/general.yaml
@@ -111,7 +111,7 @@
   match: "count(*)=2 and contains(@data-intent-property, ':infix:')"
   replace:
   - x: "*[2]"
-  - t: "パーミュテーションの"      # phrase(the solution  involves several 'permutations of' values)
+  - t: "順列の"      # phrase(the solution  involves several 'permutations of' values)
   - x: "*[1]"
 
 - name: intervals

--- a/Rules/Languages/ja/unicode.yaml
+++ b/Rules/Languages/ja/unicode.yaml
@@ -73,7 +73,7 @@
             else: [t: "感嘆符"]          # 0x21
         else: [t: "階乗"]                     # 0x21
           
- - "\"": [t: "引用の印"]                     # 0x22
+ - "\"": [t: "引用符"]                     # 0x22
  - "#": [t: "番号記号"]                              # 0x23
  - "$": [t: "ドル"]                             # 0x24
  - "%": [t: "パーセント"]                             # 0x25
@@ -150,8 +150,8 @@
          if: "$Verbosity!='Terse'"
          then: [t: "は"]
      - t: "より大きい"
- - "?": [t: "質問の印"]                       # 0x3f
- - "@": [t: "サインイン"]                             # 0x40
+ - "?": [t: "疑問符"]                       # 0x3f
+ - "@": [t: "アットマーク"]                             # 0x40
  - "[":                                          # 0x5b
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
@@ -182,7 +182,7 @@
         replace:
         - test:
             - if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
-              then: [t: "縦ライン"]
+              then: [t: "縦線"]
             - else_if: "$SpeechStyle != 'ClearSpeak'"
               then_test:
                 - if: "$DefaultToGiven"
@@ -190,9 +190,9 @@
                 - else_if: "preceding-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))] and 
                             following-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))]"
                   then: [t: "割り切る"]
-                  else: [t: "縦ライン"]
+                  else: [t: "縦線"]
             - else_if: "not(preceding-sibling::*) or not(following-sibling::*)"
-              then: [t: "縦ライン"]
+              then: [t: "縦線"]
             - else_if: "$ClearSpeak_VerticalLine = 'SuchThat'"
               then: [t: "そのようなこと"]
             - else_if: "$ClearSpeak_VerticalLine = 'Given' or $DefaultToGiven"
@@ -272,25 +272,25 @@
  - "γ": [t: "ガンマ"]                               # 0x3b3
  - "δ": [t: "デルタ"]                               # 0x3b4
  - "ε": [t: "エプシロン"]                             # 0x3b5
- - "ζ": [t: "ゼタ"]                                # 0x3b6
+ - "ζ": [t: "ゼータ"]                                # 0x3b6
  - "η": [t: "エータ"]                                 # 0x3b7
  - "θ": [t: "シータ"]                               # 0x3b8
- - "ι": [t: "オクタ"]                                # 0x3b9
+ - "ι": [t: "イオタ"]                                # 0x3b9
  - "κ": [t: "カッパ"]                               # 0x3ba
  - "λ": [t: "ラムダ"]                               # 0x3bb
  - "μ": [t: "ミュー"]                                  # 0x3bc
  - "ν": [t: "ニュー"]                                  # 0x3bd
- - "ξ": [t: ""]                                 # 0x3be
+ - "ξ": [t: "クサイ"]                                 # 0x3be
  - "ο": [t: "オミクロン"]                             # 0x3bf
  - "π": [t: "パイ"]                                  # 0x3c0
  - "ρ": [t: "ロー"]                                 # 0x3c1
  - "ς": [t: "最終シグマ"]                         # 0x3c2
  - "σ": [t: "シグマ"]                               # 0x3c3
  - "τ": [t: "タウ"]                                 # 0x3c4
- - "υ": [t: "アップサイロン"]                             # 0x3c5
+ - "υ": [t: "ウプシロン"]                             # 0x3c5
  - "φ": [t: "ファイ"]                                 # 0x3c6
  - "χ": [t: "カイ"]                                 # 0x3c7
- - "ψ": [t: "プッシー"]                                 # 0x3c8
+ - "ψ": [t: "プサイ"]                                 # 0x3c8
  - "ω": [t: "オメガ"]                               # 0x3c9
  - "ϕ": [t: "ファイ"]                                 # 0x3d5
  - "ϖ": [t: "パイ"]                                  # 0x3d6
@@ -314,7 +314,7 @@
  - "⁣": [t: ""]                                   # 0x2063
  - "⁤": [t: "および"]                                # 0x2064
  - "ℂℕℚℝℤ":     # here we rely on this running through the table again to speak "cap xxx"
-    - t: "ダブルタック"
+    - t: "黒板太字"
     - spell: "translate('.', 'ℂℕℚℝℤ', 'CNQRZ')"
 
  - "℃": [t: "摂氏温度"]                     # 0x2103
@@ -330,14 +330,14 @@
     - spell: "translate('.', 'ⅆⅇⅈⅉ', 'deij')"
 
  - "←": [t: "左矢印"]                     # 0x2190
- - "↑": [t: "上下矢印"]                       # 0x2191
+ - "↑": [t: "上矢印"]                       # 0x2191
  - "→":                                          # 0x2192
      - test:
         if: "ancestor::*[2][self::m:limit]"
-        then: [t: "アプローチ"]
+        then: [t: "近づく"]
         else: [t: "右矢印"]
 
- - "↓": [t: "ダウン矢印"]                     # 0x2193
+ - "↓": [t: "下矢印"]                     # 0x2193
  - "∈":                                          # 0x2208
      - test:
         if: "$SpeechStyle != 'ClearSpeak'"
@@ -353,22 +353,22 @@
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
                 then: [t: "中へ"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "メンバー"]
+                then: [t: "元"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
                 then: [t: "要素の"]
               - else: [t: "に属する"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
             else_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "メンバー"]
+                then: [t: "元"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "の要素は"]
+                then: [t: "要素"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'In'
                 then: [t: "に含まれる"]
-              - else: [t: "所属団体"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+              - else: [t: "属する"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
  - "∥":                                           # 0x2225
      - test:
          if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
-         then: [t: "二重縦ライン"]
+         then: [t: "二重縦線"]
          else:
          - test:
               if: "$Verbosity!='Terse'"
@@ -398,7 +398,7 @@
                # must be ClearSpeak and $ClearSpeak_Ellipses = 'AndSoOn'
                # speak '…' as 'and so on...' unless expr starts with '…'
             - "../*[1][.='…']"
-        then: [t: "ドットドットドットドット"]
+        then: [t: "ドットドットドット"]
         else_test:  # must have $ClearSpeak_Ellipses = 'AndSoOn'
             if: "count(following-sibling::*) = 0"
             then: [t: "以下同様"]
@@ -406,13 +406,13 @@
  - "∂":                                          # 0x2202
      - test: 
          if: "$Verbosity='Terse'"
-         then: [t: "部分的な"]
-         else: [t: "部分的な派生物"]
+         then: [t: "ラウンド"]
+         else: [t: "偏微分"]
  - "∆":                                          # 0x2206
      - test: 
          if: "$Verbosity!='Terse'"
          then: [ot: ""]
-     - t: "ラップラキアンの"
+     - t: "ラプラシアンの"
  - "∉":                                          # 0x2209
     # rule is identical to 0x2208
      - test:
@@ -429,18 +429,18 @@
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
                 then: [t: "に含まれない"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "会員でない"]
+                then: [t: "元でない"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
                 then: [t: "要素ではない"]
-              - else: [t: "お持ちでない"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
+              - else: [t: "属さない"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
             else_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "会員でない"]
+                then: [t: "元でない"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
                 then: [t: "要素ではない"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'In'
-                then: [t: "ない"]
-              - else: [t: "所属しない"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+                then: [t: "含まれない"]
+              - else: [t: "属さない"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
  - "∊":                                          # 0x220a
      - test:
         if: "$SpeechStyle != 'ClearSpeak'"
@@ -456,18 +456,18 @@
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
                 then: [t: "中へ"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "メンバー"]
+                then: [t: "元"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
                 then: [t: "要素の"]
               - else: [t: "に属する"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
             else_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "メンバー"]
+                then: [t: "元"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "の要素は"]
+                then: [t: "要素"]
               - else_if: $ClearSpeak_SetMemberSymbol = 'In'
                 then: [t: "に含まれる"]
-              - else: [t: "所属団体"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+              - else: [t: "属する"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
  - "√":                                          # 0x221a
      - test: 
          if: "$Verbosity!='Terse'"
@@ -530,5 +530,5 @@
      - t: "スーパーセットまたは等しく"
 
  # --- restored short definitions that differ from unicode-full ---
- - "⇒": [t: "右ダブル矢印"]             # 0x21d2
- - "∐": [t: "共産品"]                          # 0x2210
+ - "⇒": [t: "右二重矢印"]             # 0x21d2
+ - "∐": [t: "余積"]                          # 0x2210

--- a/Rules/Languages/ja/unicode.yaml
+++ b/Rules/Languages/ja/unicode.yaml
@@ -5,7 +5,7 @@
  - "a": 
     - test: 
         if: "$TTS='none'"
-        then: [t: "イーグル"]                         # long "a" sound in all speech engines I tested (espeak, MS SAPI, eloquence,
+        then: [t: "エー"]                         # long "a" sound in all speech engines I tested (espeak, MS SAPI, eloquence,
         else: [spell: "'a'"]                         #    AWS Polly, ReadSpeaker, NaturalReader, google cloud, nuance, ibm watson)
  - "b-z": 
     - test: 
@@ -37,7 +37,7 @@
         replace:
         - test:
             if: "$TTS='none'"
-            then: [t: "イーグル"]
+            then: [t: "エー"]
             else: [spell: "'a'"]
             
  - "B-Z":
@@ -70,8 +70,8 @@
         then_test:
             if: "$Verbosity = 'Terse'"
             then: [t: "バング"]                      # 0x21
-            else: [t: "排除ポイント"]          # 0x21
-        else: [t: "ファクシャル"]                     # 0x21
+            else: [t: "感嘆符"]          # 0x21
+        else: [t: "階乗"]                     # 0x21
           
  - "\"": [t: "引用の印"]                     # 0x22
  - "#": [t: "番号記号"]                              # 0x23
@@ -189,7 +189,7 @@
                   then: [t: "与えられた"]
                 - else_if: "preceding-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))] and 
                             following-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))]"
-                  then: [t: "分割する"]
+                  then: [t: "割り切る"]
                   else: [t: "縦ライン"]
             - else_if: "not(preceding-sibling::*) or not(following-sibling::*)"
               then: [t: "縦ライン"]
@@ -197,7 +197,7 @@
               then: [t: "そのようなこと"]
             - else_if: "$ClearSpeak_VerticalLine = 'Given' or $DefaultToGiven"
               then: [t: "与えられた"] 
-            - else: [t: "分割する"]                   
+            - else: [t: "割り切る"]                   
 
  - "}":                                          # 0x7d
     - test:
@@ -373,22 +373,22 @@
          - test:
               if: "$Verbosity!='Terse'"
               then: [t: "は"]
-         - t: "平行へ"
+         - t: "平行"
  - "∦":                                           # 0x2226
      - test: 
          if: "$Verbosity!='Terse'"
          then: [t: "は"]
-     - t: "並行しない"
+     - t: "平行でない"
  - "≤":                                          # 0x2264
      - test: 
          if: "$Verbosity!='Terse'"
          then: [t: "は"]
-     - t: "より少しまたは等しい"
+     - t: "より小さいか等しい"
  - "≥":                                          # 0x2265
      - test: 
          if: "$Verbosity!='Terse'"
          then: [t: "は"]
-     - t: "より大きいか等しいへの"
+     - t: "より大きいか等しい"
 
  # --- restored complex short definitions (prefer over unicode-full) ---
  - "…":                                          # 0x2026
@@ -497,7 +497,7 @@
      - test: 
          if: "$Verbosity!='Terse'"
          then: [t: "は"]
-     - t: "同じ"
+     - t: "恒等的に等しい"
  - "⊂":                                          # 0x2282
      - test: 
          if: "$Verbosity!='Terse'"

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -273,6 +273,42 @@ fn letter_a() -> Result<()> {
     return Ok(());
 }
 
+/// Five Greek letters were wrong and ξ was silent: it had an empty string, so a
+/// formula using it simply skipped the variable. ゼタ is the SI prefix zetta,
+/// オクタ is "octa", and プッシー is an offensive English word.
+#[test]
+fn greek_letters_that_were_wrong() -> Result<()> {
+    for (letter, expected) in [
+        ("&#x3b6;", "ゼータ"),
+        ("&#x3b9;", "イオタ"),
+        ("&#x3be;", "クサイ"),
+        ("&#x3c5;", "ウプシロン"),
+        ("&#x3c8;", "プサイ"),
+    ] {
+        let expr = format!("<math><mi>{letter}</mi></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// ∂ said 部分的な派生物 -- "a partially derived object". The symbol is read
+/// ラウンド and the concept is 偏微分.
+#[test]
+fn partial_derivative_symbol() -> Result<()> {
+    let expr = "<math><mo>&#x2202;</mo></math>";
+    test("ja", "ClearSpeak", expr, "偏微分")?;
+    return Ok(());
+}
+
+/// Set membership was worded as club membership: メンバー, 会員でない
+/// ("not a club member") and 所属団体 ("the organization one belongs to").
+#[test]
+fn set_non_membership() -> Result<()> {
+    let expr = "<math><mi>x</mi><mo>&#x2209;</mo><mi>y</mi></math>";
+    test("ja", "ClearSpeak", expr, "x 元でない y")?;
+    return Ok(());
+}
+
 /// 平行 and 垂直 are the geometric relations. The seed used 平行へ and 垂直へ,
 /// which attach a direction particle that cannot follow a noun this way, and
 /// wrote the negative form with 並行 -- a different word, meaning "concurrent".

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -262,6 +262,54 @@ fn set_membership() -> Result<()> {
     return Ok(());
 }
 
+/// The seed read the variable a as イーグル -- an eagle. The English rule says
+/// "eigh" only because the letter a and the article "a" sound alike in English;
+/// the note to translators at the top of unicode.yaml says most languages do not
+/// need this. Japanese reads the letter as エー, and 大文字 エー when capital.
+#[test]
+fn letter_a() -> Result<()> {
+    let expr = "<math><mi>a</mi><mo>+</mo><mi>b</mi></math>";
+    test("ja", "ClearSpeak", expr, "エー プラス b")?;
+    return Ok(());
+}
+
+/// 平行 and 垂直 are the geometric relations. The seed used 平行へ and 垂直へ,
+/// which attach a direction particle that cannot follow a noun this way, and
+/// wrote the negative form with 並行 -- a different word, meaning "concurrent".
+#[test]
+fn parallel_and_perpendicular() -> Result<()> {
+    for (op, expected) in [
+        ("&#x2225;", "x は 平行 y"),
+        ("&#x2226;", "x は 平行でない y"),
+    ] {
+        let expr = format!("<math><mi>x</mi><mo>{op}</mo><mi>y</mi></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// ≤ said より少しまたは等しい ("a little more, or equal") and ≥ ended in the
+/// particle へ.
+#[test]
+fn comparison_with_equality() -> Result<()> {
+    for (op, expected) in [
+        ("&#x2264;", "x は より小さいか等しい 5"),
+        ("&#x2265;", "x は より大きいか等しい 5"),
+    ] {
+        let expr = format!("<math><mi>x</mi><mo>{op}</mo><mn>5</mn></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// A factorial is 階乗. ファクシャル is not a Japanese word.
+#[test]
+fn factorial() -> Result<()> {
+    let expr = "<math><mn>5</mn><mo>!</mo></math>";
+    test("ja", "ClearSpeak", expr, "5 階乗")?;
+    return Ok(());
+}
+
 /// Verifies the seeded Japanese cues for a summation with limits.
 #[test]
 fn summation() -> Result<()> {


### PR DESCRIPTION
Same defect as #734, in the symbols rather than the accents: the seed translated
the English source word in its everyday sense, so several of these say something
unrelated. The matching entries in `definitions.yaml` are in #730; this PR is
the rule files.

Only strings change. No rule is added, removed, or restructured, and
`audit-translations ja` reports the same 28 rule differences as `ja` does.

### The letter `a` was read as an eagle

`unicode.yaml` starts with a note to translators:

> most languages don't have two ways to pronounce 'a' -- if not need, remove the
> rules and change "b-z" to "a-z"

English needs the special case because the letter *a* and the article *a* sound
alike, so with no TTS it says "eigh". Japanese has no such ambiguity, and the
seed rendered "eigh" as **イーグル** — an eagle. Both the lowercase and the
uppercase rule had it, so every formula containing the variable `a` said "eagle".
It now says エー (and 大文字 エー when capital).

I kept the rule structure instead of deleting it as the note allows: removing it
would leave `Missing rules: 2` in `audit-translations` permanently, and
`# audit-ignore` does not suppress that category. Say the word if you would
rather have the rules removed — the spoken result is the same either way.

### The rest

| symbol | English | Japanese was | which means | now |
| --- | --- | --- | --- | --- |
| `∥` 0x2225 | parallel to | 平行へ | a direction particle that cannot follow this noun | 平行 |
| `∦` 0x2226 | not parallel to | 並行しない | 並行 is *concurrent*, a different word from 平行 | 平行でない |
| `≤` 0x2264 | less than or equal to | より少しまたは等しい | "a little more, or equal" | より小さいか等しい |
| `≥` 0x2265 | greater than or equal to | より大きいか等しいへの | trailing particle, ungrammatical | より大きいか等しい |
| `≡` 0x2261 | identical to | 同じ | "the same", weaker than the relation | 恒等的に等しい |
| `!` 0x21 | factorial | ファクシャル | not a word | 階乗 |
| `!` 0x21 (literal) | exclamation point | 排除ポイント | "exclusion point" | 感嘆符 |
| `∣` | divides | 分割する | to split a thing into parts, not divisibility | 割り切る |
| pochhammer | permutations of | パーミュテーションの | transliteration | 順列の |

`分割する` appeared in both branches of the vertical-line rule, and 平行/並行 are
distinct words that a reader cannot tell apart by ear in context, so the
negative form was asserting something else entirely.

### Tests

Five assertions in `tests/Languages/ja/ja.rs`: the letter `a`, the two parallel
relations, the two comparisons with equality, and a factorial.

The tests use `x` and `y` rather than `a` and `b` on purpose, so that they do not
depend on the letter-`a` rule this PR changes.
