### PR TITLE
pl: fix five speech/navigation defects and catch up with recent en changes

### DIFF
--- a/Rules/Languages/pl/SharedRules/default.yaml
+++ b/Rules/Languages/pl/SharedRules/default.yaml
@@ -737,21 +737,38 @@
 
 - name: function-intent
   # uncaught intent -- speak as foo of arg1 comma arg2 .... The MathML spec requires arguments to functions
+  # IntentMappings mogą dodać po nazwie opcje spoiwa "| ...":
+  #   * jedna opcja bez przecinka: separator dwuargumentowy po "z"
+  #     (np. "| podzielone przez" daje "część całkowita z x podzielone przez y")
+  #   * wiele opcji albo opcja z przecinkami: szablony arności; k słów spoiwa
+  #     opisuje k+1 argumentów (np. "| po | od,do")
+  #   * gdy arność nie pasuje, argumenty rozdziela przecinek
   tag: "*"
   match: "count(*)>0"
   replace:
   - x: "SpeakIntentName(name(.), $Verbosity, 'function')"
   - test:
-      if: "$Verbosity != 'Terse' and not(contains(@data-intent-property, ':literal:')) and
-           not(count(*)=2 and (IsInDefinition(*[1], 'TrigFunctionNames') or IsInDefinition(name(.), 'TerseFunctionNames')) and IsNode(*[2], 'simple'))"
-      then: [T: "z", pause: auto]      # phrase(sine 'of' 5)
-  - insert:
-      nodes: "*"
-      replace:
-      - test:
-          if: "not(contains(@data-intent-property, ':literal:'))"
-          then: [x: "','"]
+    - if: "IntentFunctionUseArityPath(name(.), 'function', count(*))"
+      then:
+      - x: "IntentFunctionGlueBefore(name(.), 'function', 1, count(*))"
       - pause: auto
+      - insert:
+          nodes: "*"
+          replace:
+          - x: "IntentFunctionGlueBefore(name(.), 'function', $InsertIndex, count(*))"
+          - pause: auto
+      else:
+      - test:
+          if: "$Verbosity != 'Terse' and not(contains(@data-intent-property, ':literal:')) and
+               not(count(*)=2 and (IsInDefinition(*[1], 'TrigFunctionNames') or IsInDefinition(name(.), 'TerseFunctionNames')) and IsNode(*[2], 'simple'))"
+          then: [T: "z", pause: auto]      # phrase(sine 'of' 5)
+      - insert:
+          nodes: "*"
+          replace:
+          - test:
+              if: "not(contains(@data-intent-property, ':literal:'))"
+              then: [x: "IntentFunctionArgSeparator(name(.), 'function', count(*))"]
+          - pause: auto
   - test:
       # speak "end ..." if not bracketed or last child is not simple and not last node
       if: "$Impairment = 'Blindness' and not(*[last()][IsBracketed(., '', '') or IsNode(., 'simple')] )"

--- a/Rules/Languages/pl/SharedRules/default.yaml
+++ b/Rules/Languages/pl/SharedRules/default.yaml
@@ -514,6 +514,18 @@
       - pause: medium
   - x: "*"
   - test:
+      if: "HasVisibleColumnLine(../.., count(preceding-sibling::*) + 1)"
+      then:
+      - pause: short
+      - T: "separator"
+  - test:
+      # Separator wiersza zapowiadamy tylko po ostatniej komórce wiersza, żeby
+      # wybrzmiał raz na każdą granicę poziomą.
+      if: "count(following-sibling::*) = 0 and HasVisibleRowLine(../.., count(../preceding-sibling::*) + 1)"
+      then:
+      - pause: short
+      - T: "separator wiersza"
+  - test:
     # short pause after each element; medium pause if last element in a row; long pause for last element in matrix
     - if: count(following-sibling::*) > 0
       then: [pause: short]

--- a/Rules/Languages/pl/SharedRules/geometry.yaml
+++ b/Rules/Languages/pl/SharedRules/geometry.yaml
@@ -57,12 +57,16 @@
 
 - name: coordinate
   tag: coordinate
-  match: "."
+  # Intencje postaci coordinate($x,...) mają @arg i spadają do function-intent / IntentMappings
+  match: "not(*[@arg])"
   replace:
-  - T: "przecinek"      # phrase(the 'point' at 1, 2)
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "w"]      # phrase('the' point at 1, 2)
+      then: [OT: "ten"]      # phrase('the' point at 1, 2)
+  - T: "punkt"      # phrase(the 'point' at 1, 2)
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [T: "w"]      # phrase('the' point at 1, 2)
   - pause: short
   - insert:
       nodes: "*"

--- a/Rules/Languages/pl/definitions.yaml
+++ b/Rules/Languages/pl/definitions.yaml
@@ -13,9 +13,9 @@
 
     "image":"function=obraz", 
     "mixed-fraction":"infix=i",
-    "quotient":"function=część całkowita; podzielone przez",
+    "quotient":"function=część całkowita | podzielone przez",
     "evaluated-at":"infix=obliczone w",
-    "remainder":"function=reszta; podzielone przez",
+    "remainder":"function=reszta | podzielone przez",
 
     "max":"function=maksimum",
     "min":"function=minimum",
@@ -32,10 +32,10 @@
     "real-part": "function=część rzeczywista",
     "imaginary-part": "function=część urojona: część urojona: część urojona",
 
-    "polar-coordinate":"function=współrzędna biegunowa; przecinek",
-    "spherical-coordinate":"function=współrzędna sferyczna; przecinek; przecinek",
-    "cartesian-coordinate":"function=współrzędna kartezjańska; przecinek",
-    "coordinate":"function=współrzędna; przecinek",
+    "polar-coordinate":"function=współrzędna biegunowa",
+    "spherical-coordinate":"function=współrzędna sferyczna",
+    "cartesian-coordinate":"function=współrzędna kartezjańska",
+    "coordinate":"function=współrzędna",
     "floor":"function=podłoga",
     "ceiling":"function=sufit",
     "round":"function=zaokrąglenie",
@@ -51,16 +51,23 @@
 
     ### Sets
     "set": "function=; zbiór: zbiór",
-    "set-difference":"function=różnica zbiorów; i || infix=minus", # NOTE: not tested
+    "set-difference":"function=różnica zbiorów | i || infix=minus",
     "complement":"function=dopełnienie",
+    "empty-set":"nofix=zbiór pusty",
     "cardinality":"function=moc zbioru",
     "list":"function=lista",
     "tuple": "function=; krotka: krotka",
 
 
     ### Sequence and Series
-    "sum":"function=; suma po: suma; ",
-    "product":"function=iloczyn || function=iloczyn po || function=iloczyn od; do",
+    # UWAGA: NIE używamy tu szablonów arności ("| po | od,do"), choć angielski je ma.
+    # Powód (zmierzone 31.08.2026): intent_function_glue_before w src/infer_intent.rs
+    # zwraca dla ostatniego argumentu ZASZYTE W KODZIE angielskie "of", więc polskie
+    # wyjście brzmiałoby "suma po i of x". To defekt rdzenia dotyczący każdego języka
+    # poza angielskim; węgierski uniknął go tak samo, zostawiając prostą postać.
+    # Separator binarny (jedna opcja "| słowo") działa poprawnie i jest używany niżej.
+    "sum":"function=suma",
+    "product":"function=iloczyn",
 
 
     ### Elementary classical functions
@@ -104,7 +111,7 @@
     "median":"function=mediana",
     "mode":"function=dominanta",
 
-    "conditional-probability":"function=prawdopodobieństwo; pod warunkiem", # NOTE: Check test
+    "conditional-probability":"function=prawdopodobieństwo | pod warunkiem",
 
 
     ### Linear Algebra
@@ -120,7 +127,7 @@
     "unit-vector":"prefix=wektor jednostkowy",
 
     "identity-matrix":"nofix=macierz jednostkowa", # NOTE: no function specified
-    "transpose":"function=transpozycja || postfix=transponowane",
+    "transpose":"postfix=transponowane || function=transpozycja",
     "dimensional-product":"infix=na", # INFIX
 
 
@@ -150,13 +157,13 @@
 
     ### General Concepts 
     "fenced-group":"function=grupa w nawiasach",
-    "ordered-pair": "function=; para; i",
+    "ordered-pair": "function=para | i",
     "indexed-by": "infix=; indeks dolny; koniec indeksu dolnego",
     
     "highlight":"postfix=podświetlone",
     "least-common-denominator":"function=najmniejszy wspólny mianownik",
     "rate":"infix=na",
-    "translation":"function=przesunięcie o; przecinek",
+    "translation":"function=przesunięcie o",
     "constraint":"infix=; przy warunku; ", 
     
     "binomial-coefficient":"infix=po",
@@ -264,7 +271,7 @@
     ## Default fixity nofix
     "diameter":"nofix=d: średnica",
     "distance":"nofix=d; D: odległość",
-    "probability":"nofix=P: prawdopodobieństwo",
+    "probability":"nofix=P: prawdopodobieństwo || function=prawdopodobieństwo",
     "radius":"nofix=r: promień",
     "volume":"nofix=V: objętość || function=objętość",
     "exponential-e":"nofix=e",

--- a/Rules/Languages/pl/navigate.yaml
+++ b/Rules/Languages/pl/navigate.yaml
@@ -53,39 +53,46 @@
         then: [t: "maksymalnie oddalono", pause: "medium"]
         else:
         - test:
-          - if: "starts-with($NavCommand, 'Zoom')"
-            then: [set_variables: [Prefix: "'przybliż'"]]          # phrase('zoom' in to see more details)     
+          # CommandOffset to 1 + długość ANGIELSKIEGO rdzenia $NavCommand
+          # (Zoom/Move/Read/Describe), a NIE długość wymawianego $Prefix -
+          # dzięki temu tłumaczenie może mieć słowo Prefix innej długości.
+          # Angielskie "zoom" obsługuje oba kierunki, polski ma dwa różne
+          # czasowniki - "przybliż na zewnątrz" byłoby sprzeczne.
+          - if: "starts-with($NavCommand, 'ZoomOut')"
+            then: [set_variables: [Prefix: "'oddal'", CommandOffset: "5"]]             # phrase('zoom' out to see less detail)
+          - else_if: "starts-with($NavCommand, 'Zoom')"
+            then: [set_variables: [Prefix: "'przybliż'", CommandOffset: "5"]]          # phrase('zoom' in to see more details)
           - else_if: "starts-with($NavCommand, 'Move')"
-            then: [set_variables: [Prefix: "'przejdź'"]]          # phrase('move' to next entry in table)     
+            then: [set_variables: [Prefix: "'przejdź'", CommandOffset: "5"]]          # phrase('move' to next entry in table)
           - else_if: "starts-with($NavCommand, 'Read')"
-            then: [set_variables: [Prefix: "'odczytaj'"]]          # phrase('read' to next entry in table)     
+            then: [set_variables: [Prefix: "'odczytaj'", CommandOffset: "5"]]          # phrase('read' to next entry in table)
           - else_if: "starts-with($NavCommand, 'Describe')"
-            then: [set_variables: [Prefix: "'opisz'"]]      # phrase('describe' to next entry in table)
+            then: [set_variables: [Prefix: "'opisz'", CommandOffset: "9"]]      # phrase('describe' to next entry in table)
         - test:
             if: "$Prefix != ''"
             then:
             - x: "$Prefix"
             - test:
-              - if: "substring($NavCommand, string-length($Prefix)+1) = 'In'"
-                then: [T: "do"]                                  # phrase(zoom 'in' to see more details)
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'InAll'"
+              - if: "substring($NavCommand, $CommandOffset) = 'In'"
+                then: []                                         # sam czasownik "przybliż" wystarcza
+              - else_if: "substring($NavCommand, $CommandOffset) = 'InAll'"
                 # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets "ed" concatenated to "zoom"
-                then: [t: "maksymalnie do środka"]                     # phrase(zoom 'out all the way' to see more details)
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Out'"
-                then: [t: "na zewnątrz"]                                 # phrase(zoom 'out' to see more details)
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'OutAll'"
+                then: [T: "maksymalnie"]                          # phrase(zoom 'in all of the way' to see more details)
+              - else_if: "substring($NavCommand, $CommandOffset) = 'Out'"
+                then: []                                         # sam czasownik "oddal" wystarcza
+              - else_if: "substring($NavCommand, $CommandOffset) = 'OutAll'"
                 # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets "ed" concatenated to "zoom"
-                then: [t: "maksymalnie na zewnątrz"]                     # phrase(zoom 'out all the way' to see more details)
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Next'"
-                then: [t: "w prawo"]                               # phrase(move to the 'right')
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Previous'"
-                then: [t: "w lewo"]                                # phrase(move to the 'left')
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Current'"
-                then: [t: "bieżący"]                                 # phrase(who is the 'current' president)
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'LineStart'"
-                then: [t: "do początku linii"]                                 # phrase(move 'to start of line')
-              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'LineEnd'"
-                then: [t: "do końca linii"]                                 # phrase(move 'to end of line')
+                then: [T: "maksymalnie"]                          # phrase(zoom 'out all of the way' to see more details)
+              - else_if: "substring($NavCommand, $CommandOffset) = 'Next'"
+                then: [T: "w prawo"]                               # phrase(move to the 'right')
+              - else_if: "substring($NavCommand, $CommandOffset) = 'Previous'"
+                then: [T: "w lewo"]                                # phrase(move to the 'left')
+              - else_if: "substring($NavCommand, $CommandOffset) = 'Current'"
+                then: [T: "bieżący"]                                 # phrase(who is the 'current' president)
+              - else_if: "substring($NavCommand, $CommandOffset) = 'LineStart'"
+                then: [T: "do początku linii"]                                 # phrase(move 'to start of line')
+              - else_if: "substring($NavCommand, $CommandOffset) = 'LineEnd'"
+                then: [T: "do końca linii"]                                 # phrase(move 'to end of line')
             - pause: "medium"
   - set_variables: [MatchCounter: "$MatchCounter + 1"]
 
@@ -94,6 +101,15 @@
   # saying "out of row n" is not very useful, so skip it
   match: "$Move2D != '' and (not(@data-from-mathml) or @data-from-mathml = name(.)) and
           (name(.)='mrow' or name(.) = 'mtr' or name(.) = 'mlabeledtr' or @data-from-mathml = 'mtable')"
+  replace: []
+
+- name: into-or-out-of-prefix-or-silent-without-parts
+  tag: "*"
+  # Intencje prefiksowe i ciche bez wpisu w NavigationParts (np. minus unarny,
+  # x z daszkiem) NIE powinny zapowiadać "do"/"na zewnątrz".
+  match: "$Move2D != '' and
+          (contains(@data-intent-property, ':prefix:') or contains(@data-intent-property, ':silent:')) and
+          GetNavigationPartName(name(.), count($Child2D/preceding-sibling::*)) = ''"
   replace: []
 
 - name: into-or-out-of-mtr
@@ -168,6 +184,24 @@
       - test:
         - if: "$PartName != ''"
           then: [x: "$PartName"]
+        - else_if: "count(*) = 1"
+          then_test:
+            if: "$NavVerbosity = 'Verbose'"
+            then:   # IntentMappings przez SpeakIntentName; w razie braku - nazwa intentu ze spacjami
+            - test:
+              - if: "contains(@data-intent-property, ':prefix:')"
+                then: [x: "SpeakIntentName(name(.), $Verbosity, 'prefix')"]
+              - else_if: "contains(@data-intent-property, ':postfix:')"
+                then: [x: "SpeakIntentName(name(.), $Verbosity, 'postfix')"]
+              - else_if: "contains(@data-intent-property, ':infix:')"
+                then: [x: "SpeakIntentName(name(.), $Verbosity, 'infix')"]
+              - else_if: "contains(@data-intent-property, ':function:')"
+                then: [x: "SpeakIntentName(name(.), $Verbosity, 'function')"]
+              - else_if: "contains(@data-intent-property, ':nofix:')"
+                then: [x: "SpeakIntentName(name(.), $Verbosity, 'nofix')"]
+              - else_if: "contains(@data-intent-property, ':silent:')"
+                then: [x: "SpeakIntentName(name(.), $Verbosity, 'silent')"]
+              - else: [x: "SpeakIntentName(name(.), $Verbosity, 'other')"]
           else:
           - t: "części"         # phrase(the 'part' of the expression)
           - x: "count($Child2D/preceding-sibling::*) + 1"

--- a/Rules/Languages/pl/unicode-full.yaml
+++ b/Rules/Languages/pl/unicode-full.yaml
@@ -291,7 +291,7 @@
  - "†": [t: "obelisk"]                              # 0x2020
  - "‡": [t: "podwójny obelisk"]                       # 0x2021
 
- - " - ": [t: " "]                                 # 0x2000 - 0x2007
+ - " - ": [T: " "]                                 # 0x2000 - 0x2007
 
  - "•":                                            # 0x2022
     - test: 
@@ -344,7 +344,7 @@
  - "⁑": [t: "dwie pionowe gwiazdki"]              # 0x2051
  - "⁒": [t: "handlowy znak minus"]               # 0x2052
  - "⁗": [t: "poczwórny prim"]                     # 0x2057
- - "⁠": [t: ""]                                     # 0x2060
+ - "⁠": [T: ""]                                     # 0x2060
  - "⁰": [t: "do zerowej potęgi"]                 # 0x2070
  - "ⁱ": [t: "do potęgi i"]                     # 0x2071
  - "⁴": [t: "do czwartej potęgi"]                 # 0x2074
@@ -409,7 +409,7 @@
  - "₴": [t: "hrywny"]                            # 0x20b4
  - "₵": [t: "cedi"]                               # 0x20b5
  - "₶": [t: "liwr turoński"]                      # 0x20b6
- - "₷": [t: "spesmilos"]                           # 0x20b7
+ - "₷": [T: "spesmilos"]                           # 0x20b7
  - "₸": [t: "tenge"]                              # 0x20b8
  - "₹": [t: "rupie indyjskie"]                       # 0x20b9
  - "₺": [t: "liry tureckie"]                       # 0x20ba
@@ -473,7 +473,7 @@
  - "№": [t: "numer"]                              # 0x2116
  - "℥": [t: "uncje"]                              # 0x2125
  - "Ω": [t: "omy"]                                # 0x2126
- - "℧": [t: "mhos"]                                # 0x2127
+ - "℧": [T: "mho"]                                # 0x2127
  - "℩": [t: "odwrócony jota"]                         # 0x2129
  - "K": [t: "kelwin"]                              # 0x212a
  - "Å": [t: "angstremy"]                           # 0x212b
@@ -522,37 +522,37 @@
  - "⅞": [t: "siedem ósmych"]                       # 0x215e
  - "⅟": [t: "jeden przez"]                            # 0x215f
  - "Ⅰ": [t: "I"]                                   # 0x2160
- - "Ⅱ": [t: "I I"]                                 # 0x2161
- - "Ⅲ": [t: "I I I"]                               # 0x2162
- - "Ⅳ": [t: "I V"]                                 # 0x2163
- - "Ⅴ": [t: "V"]                                   # 0x2164
- - "Ⅵ": [t: "V I"]                                 # 0x2165
- - "Ⅶ": [t: "V I I"]                               # 0x2166
- - "Ⅷ": [t: "V I I I"]                             # 0x2167
- - "Ⅸ": [t: "I X"]                                 # 0x2168
- - "Ⅹ": [t: "X"]                                   # 0x2169
- - "Ⅺ": [t: "X I"]                                 # 0x216a
- - "Ⅻ": [t: "X I I"]                               # 0x216b
- - "Ⅼ": [t: "L"]                                   # 0x216c
- - "Ⅽ": [t: "C"]                                   # 0x216d
- - "Ⅾ": [t: "D"]                                   # 0x216e
- - "Ⅿ": [t: "M"]                                   # 0x216f
+ - "Ⅱ": [T: "I I"]                                 # 0x2161
+ - "Ⅲ": [T: "I I I"]                               # 0x2162
+ - "Ⅳ": [T: "I V"]                                 # 0x2163
+ - "Ⅴ": [T: "V"]                                   # 0x2164
+ - "Ⅵ": [T: "V I"]                                 # 0x2165
+ - "Ⅶ": [T: "V I I"]                               # 0x2166
+ - "Ⅷ": [T: "V I I I"]                             # 0x2167
+ - "Ⅸ": [T: "I X"]                                 # 0x2168
+ - "Ⅹ": [T: "X"]                                   # 0x2169
+ - "Ⅺ": [T: "X I"]                                 # 0x216a
+ - "Ⅻ": [T: "X I I"]                               # 0x216b
+ - "Ⅼ": [T: "L"]                                   # 0x216c
+ - "Ⅽ": [T: "C"]                                   # 0x216d
+ - "Ⅾ": [T: "D"]                                   # 0x216e
+ - "Ⅿ": [T: "M"]                                   # 0x216f
  - "ⅰ": [t: "I"]                                   # 0x2170
- - "ⅱ": [t: "I I"]                                 # 0x2171
- - "ⅲ": [t: "I I I"]                               # 0x2172
- - "ⅳ": [t: "I V"]                                 # 0x2173
- - "ⅴ": [t: "V"]                                   # 0x2174
- - "ⅵ": [t: "V I"]                                 # 0x2175
- - "ⅶ": [t: "V I I"]                               # 0x2176
- - "ⅷ": [t: "V I I I"]                             # 0x2177
- - "ⅸ": [t: "I X"]                                 # 0x2178
- - "ⅹ": [t: "X"]                                   # 0x2179
- - "ⅺ": [t: "X I"]                                 # 0x217a
- - "ⅻ": [t: "X I I"]                               # 0x217b
- - "ⅼ": [t: "L"]                                   # 0x217c
- - "ⅽ": [t: "C"]                                   # 0x217d
- - "ⅾ": [t: "D"]                                   # 0x217e
- - "ⅿ": [t: "M"]                                   # 0x217f
+ - "ⅱ": [T: "I I"]                                 # 0x2171
+ - "ⅲ": [T: "I I I"]                               # 0x2172
+ - "ⅳ": [T: "I V"]                                 # 0x2173
+ - "ⅴ": [T: "V"]                                   # 0x2174
+ - "ⅵ": [T: "V I"]                                 # 0x2175
+ - "ⅶ": [T: "V I I"]                               # 0x2176
+ - "ⅷ": [T: "V I I I"]                             # 0x2177
+ - "ⅸ": [T: "I X"]                                 # 0x2178
+ - "ⅹ": [T: "X"]                                   # 0x2179
+ - "ⅺ": [T: "X I"]                                 # 0x217a
+ - "ⅻ": [T: "X I I"]                               # 0x217b
+ - "ⅼ": [T: "L"]                                   # 0x217c
+ - "ⅽ": [T: "C"]                                   # 0x217d
+ - "ⅾ": [T: "D"]                                   # 0x217e
+ - "ⅿ": [T: "M"]                                   # 0x217f
  - "↉": [t: "zero trzecich"]                         # 0x2189
  - "↔": [t: "lewy strzałka w prawo"]                    # 0x2194
  - "↕": [t: "górny strzałka w dół"]                       # 0x2195
@@ -1533,7 +1533,7 @@
  - "♁": [t: "Ziemia"]                               # 0x2641
  - "♂": [t: "męskie"]                                # 0x2642
  - "♃": [t: "Jowisz"]                            # 0x2643
- - "♄": [t: "Saturn"]                             # 0x2644
+ - "♄": [T: "Saturn"]                             # 0x2644
  - "♅": [t: "Uran"]                             # 0x2645
  - "♆": [t: "Neptun"]                           # 0x2646
  - "♇": [t: "Pluton"]                             # 0x2647
@@ -2353,10 +2353,10 @@
  - "⸌": [t: "lewy podniesiony pominięcia nawias kwadratowy"]        # 0x2e0c
  - "⸍": [t: "prawy podniesiony pominięcia nawias kwadratowy"]       # 0x2e0d
  - "⸎": [t: "redakcyjny koronis"]                 # 0x2e0e
- - "⸏": [t: "paragraphos"]                         # 0x2e0f
+ - "⸏": [T: "paragraphos"]                         # 0x2e0f
  - "⸐": [t: "rozwidlony paragrafos"]                  # 0x2e10
  - "⸑": [t: "odwrócony rozwidlony paragrafos"]         # 0x2e11
- - "⸒": [t: "hypodiastole"]                        # 0x2e12
+ - "⸒": [T: "hypodiastole"]                        # 0x2e12
  - "⸓": [t: "kropkowany obelos"]                       # 0x2e13
  - "⸔": [t: "dolny ancora"]                    # 0x2e14
  - "⸕": [t: "górny ancora"]                      # 0x2e15
@@ -2465,7 +2465,7 @@
  - "㍲": [t: "daltony"]                             # 0x3372
  - "㍳": [t: "jednostki astronomiczne"]                  # 0x3373
  - "㍴": [t: "bary"]                                # 0x3374
- - "㍵": [t: "o V"]                                 # 0x3375
+ - "㍵": [T: "o V"]                                 # 0x3375
  - "㍶": [t: "parseki"]                             # 0x3376
  - "㍷": [t: "decymetry"]                          # 0x3377
  - "㍸": [t: "decymetry do kwadratu"]                  # 0x3378
@@ -2558,7 +2558,7 @@
  - "㏔": [t: "milibarny"]                           # 0x33d4
  - "㏕": [t: "mile"]                                # 0x33d5
  - "㏖": [t: "mole"]                                # 0x33d6
- - "㏗": [t: "p h"]                                 # 0x33d7
+ - "㏗": [T: "p h"]                                 # 0x33d7
  - "㏘": [t: "pikometry"]                           # 0x33d8
  - "㏙": [t: "części na milion"]                    # 0x33d9
  - "㏚": [t: "petarentgeny"]                        # 0x33da
@@ -2991,30 +2991,30 @@
  - "": [t: "stała Plancka przez dwa pi kreska"]     # 0xed00
  - "": [t: "lustrzane g"]                            # 0xed01
  - "": [t: "j bez kropki"]                           # 0xed02
- - "": [t: "digamma"]                             # 0xed03
- - "ϝ": [t: "digamma"]                             # 0x3dd
- - "": [t: "d"]                                   # 0xed10
- - "ⅆ": [t: "d"]                                   # 0x2146
+ - "": [T: "digamma"]                             # 0xed03
+ - "ϝ": [T: "digamma"]                             # 0x3dd
+ - "": [T: "d"]                                   # 0xed10
+ - "ⅆ": [T: "d"]                                   # 0x2146
  - "": [t: "e"]                                   # 0xed11
  - "ⅇ": [t: "e"]                                   # 0x2147
  - "": [t: "i"]                                   # 0xed12
  - "ⅈ": [t: "i"]                                   # 0x2148
- - "": [t: "j"]                                   # 0xed13
+ - "": [T: "j"]                                   # 0xed13
  - "ⅅ":
     - spell: "translate('.', 'ⅅ', 'DD')"                                         # 0xed16, 0x2145
 
 # The private use chars are from MathType
  - "": [t: "całka krzywoliniowa z pętlą przeciwnie do ruchu wskazówek zegara"] # 0xee00
  - "": [t: "całka krzywoliniowa z pętlą zgodnie z ruchem wskazówek zegara"]     # 0xee01
- - "": [t: ""]                                  # 0xee04
- - "": [t: ""]                                  # 0xee05
- - "": [t: ""]                                  # 0xee06
- - "": [t: ""]                                  # 0xee07
- - "": [t: ""]                                  # 0xee08
- - "": [t: ""]                                  # 0xee09
- - "": [t: ""]                                  # 0xee0a
- - "": [t: ""]                                  # 0xee0b
- - "": [t: ""]                                  # 0xee0c
+ - "": [T: ""]                                  # 0xee04
+ - "": [T: ""]                                  # 0xee05
+ - "": [T: ""]                                  # 0xee06
+ - "": [T: ""]                                  # 0xee07
+ - "": [T: ""]                                  # 0xee08
+ - "": [T: ""]                                  # 0xee09
+ - "": [T: ""]                                  # 0xee0a
+ - "": [T: ""]                                  # 0xee0b
+ - "": [T: ""]                                  # 0xee0c
  - "": [t: "ozdobnik statusu połączenia"]          # 0xee0d
  - "": [t: "lewy ozdobnik statusu połączenia"]     # 0xee0e
  - "": [t: "prawy ozdobnik statusu połączenia"]    # 0xee0f
@@ -3039,24 +3039,24 @@
  - "": [t: "kreska akcent z zamkniętym okręgiem po prawej"] # 0xee23
  - "": [t: "duży kropka nad"]                     # 0xee24
  - "": [t: "znak wyrównania"]                      # 0xef00
- - "": [t: ""]                                  # 0xef01
- - "​": [t: ""]                                  # 0x200b
- - "": [t: ""]                                  # 0xef02
- - " ": [t: ""]                                  # 0x2009
- - "": [t: ""]                                  # 0xef03
- - " ": [t: ""]                                  # 0x205f
- - "": [t: ""]                                  # 0xef04
- - "": [t: ""]                                  # 0xef05
- - "": [t: ""]                                  # 0xef06
- - "": [t: ""]                                  # 0xef07
- - "": [t: ""]                                  # 0xef08
- - "": [t: ""]                                  # 0xef09
- - "": [t: ""]                                  # 0xef0a
- - " ": [t: ""]                                  # 0x200a
- - "": [t: ""]                                  # 0xef22
- - "": [t: ""]                                  # 0xef23
- - "": [t: ""]                                  # 0xef24
- - "": [t: ""]                                  # 0xef29
+ - "": [T: ""]                                  # 0xef01
+ - "​": [T: ""]                                  # 0x200b
+ - "": [T: ""]                                  # 0xef02
+ - " ": [T: ""]                                  # 0x2009
+ - "": [T: ""]                                  # 0xef03
+ - " ": [T: ""]                                  # 0x205f
+ - "": [T: ""]                                  # 0xef04
+ - "": [T: ""]                                  # 0xef05
+ - "": [T: ""]                                  # 0xef06
+ - "": [T: ""]                                  # 0xef07
+ - "": [T: ""]                                  # 0xef08
+ - "": [T: ""]                                  # 0xef09
+ - "": [T: ""]                                  # 0xef0a
+ - " ": [T: ""]                                  # 0x200a
+ - "": [T: ""]                                  # 0xef22
+ - "": [T: ""]                                  # 0xef23
+ - "": [T: ""]                                  # 0xef24
+ - "": [T: ""]                                  # 0xef29
  - "": [t: "brakujący składnik"]                        # 0xef41
  - "": [t: "całka krzywoliniowa zgodna z ruchem wskazówek zegara ze strzałką po lewej"] # 0xef80
  - "": [t: "całka z kwadrat"]                # 0xef81
@@ -3563,13 +3563,13 @@
  - "": [t: "prawy nawias klamrowy środkowy"]                     # 0xf8fd
  - "": [t: "prawy nawias klamrowy dolny"]                  # 0xf8fe
  - "": [t: "logo jabłka"]                          # 0xf8ff
- - "ﬀ": [t: "ff"]                                  # 0xfb00
+ - "ﬀ": [T: "ff"]                                  # 0xfb00
  - "ﬁ": [t: "fi"]                                  # 0xfb01
- - "ﬂ": [t: "fl"]                                  # 0xfb02
- - "ﬃ": [t: "ffi"]                                 # 0xfb03
- - "ﬄ": [t: "ffl"]                                 # 0xfb04
- - "ﬅ": [t: "ft"]                                  # 0xfb05
- - "ﬆ": [t: "st"]                                  # 0xfb06
+ - "ﬂ": [T: "fl"]                                  # 0xfb02
+ - "ﬃ": [T: "ffi"]                                 # 0xfb03
+ - "ﬄ": [T: "ffl"]                                 # 0xfb04
+ - "ﬅ": [T: "ft"]                                  # 0xfb05
+ - "ﬆ": [T: "st"]                                  # 0xfb06
  - "﬩": [t: "hebrajska litera alternatywny znak plus"]      # 0xfb29
  - "︠": [t: "lewa połowa ligatury, ozdobnik"]     # 0xfe20
  - "︡": [t: "prawa połowa ligatury, ozdobnik"]    # 0xfe21

--- a/Rules/Languages/pl/unicode-full.yaml
+++ b/Rules/Languages/pl/unicode-full.yaml
@@ -1081,11 +1081,6 @@
  - "⊢": [t: "dowodzi"]                              # 0x22a2
  - "⊣": [t: "jest dowodzone przez"]                      # 0x22a3
  - "⊤": [t: "góra"]                                 # 0x22a4
- - "⊥":                                          # 0x22a5
-     - test: 
-         if: "$Verbosity!='Terse'"
-         then: [T: "jest"]
-     - t: "dół"
  - "⊦": [t: "redukuje się do"]                          # 0x22a6
  - "⊧": [t: "modeluje"]                              # 0x22a7
  - "⊨":                                          # 0x22a8
@@ -1662,11 +1657,15 @@
  - "➾": [t: "otwarta konturowa strzałka w prawo"]      # 0x27be
  - "⟀": [t: "trójwymiarowy kąt"]             # 0x27c0
  - "⟁": [t: "biały trójkąt zawierający mały biały trójkąt"] # 0x27c1
- - "⟂":                                          # 0x27c2
-     - test: 
-         if: "$Verbosity!='Terse'"
-         then: [T: "jest"]
-     - t: "prostopadłe do"
+ - "⟂⊥":                                          # 0x27c2, 22A5 (22A5 wrongly used for perpendicular by most editors)
+     - test:
+        - if: "$SpeechStyle = 'LiteralSpeak' and text()='⊥'"   # 22A5 (up tack/bottom)
+          then: [T: "dół"]
+        - else:
+          - test:
+              if: "$Verbosity!='Terse'"
+              then: [T: "jest"]
+          - T: "prostopadłe do"
  - "⟃":                                          # 0x27c3
      - test: 
          if: "$Verbosity!='Terse'"

--- a/Rules/Languages/pl/unicode.yaml
+++ b/Rules/Languages/pl/unicode.yaml
@@ -60,9 +60,9 @@
         # note: processing of ranges converts '.' into the character, so it needs to be in quotes below
         replace: [spell: "translate('.', 'BCDEFGHIJKLMNOPQRSTUVWXYZ', 'bcdefghijklmnopqrstuvwxyz')"]
 
- - "0-9": [t: "."]
+ - "0-9": [T: "."]
 
- - " ": [t: " "]                     # 0x20
+ - " ": [T: " "]                     # 0x20
 
  - "!":                                            # 0x21
     - test:
@@ -337,8 +337,8 @@
               (@data-changed='added' and ancestor-or-self::*[contains(@data-intent-property, ':literal:')])
             )"
         then: [T: "z"]
- - "⁢": [t: ""]                                   # 0x2062
- - "⁣": [t: ""]                                   # 0x2063
+ - "⁢": [T: ""]                                   # 0x2062
+ - "⁣": [T: ""]                                   # 0x2063
  - "⁤": [T: "i"]                                # 0x2064
  - "′": [t: "prim"]                               # 0x2032
  - "″": [t: "podwójny prim"]                        # 0x2033

--- a/src/navigate.rs
+++ b/src/navigate.rs
@@ -1766,6 +1766,59 @@ mod tests {
     }
 
     #[test]
+    fn zoom_speech_pl() -> Result<()> {
+        let mathml_str = "<math id='math'><mfrac id='mfrac'>
+                <msup id='msup'><mi id='base'>b</mi><mn id='exp'>2</mn></msup>
+                <mi id='denom'>d</mi>
+            </mfrac></math>";
+        init_prefs(mathml_str, "Enhanced", "pl")?;
+        return MATHML_INSTANCE.with(|package_instance| {
+            let package_instance = package_instance.borrow();
+            let mathml = get_element(&package_instance);
+            let speech = test_command("ZoomIn", mathml, "msup")?;
+            assert_eq!("przybliż; do licznika; b do kwadratu", speech);
+            let speech = test_command("ZoomIn", mathml, "base")?;
+            assert_eq!("przybliż; do podstawy; b", speech);
+            let speech = test_command("ZoomOut", mathml, "msup")?;
+            assert_eq!("oddal; z podstawy; b do kwadratu", speech);
+            let speech = test_command("ZoomInAll", mathml, "base")?;
+            assert_eq!("przybliż maksymalnie; do podstawy; b", speech);
+            let speech = test_command("ZoomOutAll", mathml, "mfrac")?;
+            assert_eq!("oddal maksymalnie; z podstawy; z licznika; ułamek, b do kwadratu, przez d, koniec ułamka", speech);
+            return Ok( () );
+        });
+    }
+
+    #[test]
+    fn move_char_speech_pl() -> Result<()> {
+        let mathml_str = "<math display='block' id='id-0'>
+                <mrow id='id-1'>
+                <mfrac id='id-2'>
+                    <mi id='id-3'>x</mi>
+                    <mi id='id-4'>y</mi>
+                </mfrac>
+                <mo id='id-5'>&#x2062;</mo>
+                <msqrt id='id-6'><mi id='id-7'>z</mi></msqrt>
+                </mrow>
+            </math>";
+        init_prefs(mathml_str, "Character", "pl")?;
+        return MATHML_INSTANCE.with(|package_instance| {
+            let package_instance = package_instance.borrow();
+            let mathml = get_element(&package_instance);
+            test_command("ZoomInAll", mathml, "id-3")?;
+            let speech = test_command("MoveNext", mathml, "id-4")?;
+            assert_eq!("przejdź w prawo; do mianownika; y", speech);
+            let speech = test_command("MoveNext", mathml, "id-7")?;
+            assert_eq!("przejdź w prawo; z mianownika; do pierwiastka; z", speech);
+            let speech = test_command("MovePrevious", mathml, "id-4")?;
+            assert_eq!("przejdź w lewo; z pierwiastka; do mianownika; y", speech);
+            let speech = test_command("MovePrevious", mathml, "id-3")?;
+            assert_eq!("przejdź w lewo; do licznika; x", speech);
+            return Ok( () );
+        });
+    }
+
+    #[test]
     fn move_char_speech_ru() -> Result<()> {
         let mathml_str = "<math display='block' id='id-0'>
                 <mrow id='id-1'>

--- a/tests/Languages/pl/alphabets.rs
+++ b/tests/Languages/pl/alphabets.rs
@@ -392,6 +392,21 @@ fn turned() -> Result<()> {
   }
 
 #[test]
+fn up_tack_330() -> Result<()> {
+    // Znak prostopadłości i znak "dół" wyglądają identycznie, a edytory
+    // wstawiają U+22A5 tam, gdzie chodzi o prostopadłość. Dlatego oba znaki
+    // mówią "prostopadłe do", a osobna reguła LiteralSpeak zachowuje dosłowne
+    // czytanie U+22A5 jako "dół".
+    let perp = "<math><mi>a</mi><mo>⟂</mo><mi>b</mi></math>"; // 0x27c2
+    test("pl", "SimpleSpeak", perp, "a jest prostopadłe do b")?;
+    test("pl", "LiteralSpeak", perp, "a jest prostopadłe do b")?;
+    let up_tack = "<math><mi>a</mi><mo>⊥</mo><mi>b</mi></math>"; // 0x22a5
+    test("pl", "ClearSpeak", up_tack, "a jest prostopadłe do b")?;
+    test("pl", "LiteralSpeak", up_tack, "a dół b")?;
+    return Ok(());
+  }
+
+#[test]
 fn unicode_typo_regressions() -> Result<()> {
   test("pl", "SimpleSpeak", "<math><mi>ⁱ</mi></math>", "do potęgi i")?;
   test("pl", "SimpleSpeak", "<math><mi>☌</mi></math>", "koniunkcja")?;

--- a/tests/Languages/pl/definitions.rs
+++ b/tests/Languages/pl/definitions.rs
@@ -91,7 +91,14 @@ fn set_difference_basic() -> Result<()> {
       </math>
     "#;
 
-    test("pl", "ClearSpeak", expr, "i z wielka a przecinek, wielka b")?;
+    // Separator dwuargumentowy: nazwa funkcji + "z" + argumenty spięte słowem "i".
+    // Wcześniej nazwa przepadała i zostawało samo spoiwo ("i z wielka a...").
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "różnica zbiorów z wielka a i wielka b",
+    )?;
 
     Ok(())
 }
@@ -107,7 +114,9 @@ fn postfix_test() -> Result<()> {
                 <mo>T</mo>
             </msup>
             "#,
-            "transpozycja z x",
+            // Test postfiksowy: bez jawnej fixity silnik bierze PIERWSZĄ z listy
+            // w IntentMappings, a tam (jak w EN) postfix jest pierwszy.
+            "x transponowane",
         ),
         (
             "highlight",
@@ -205,9 +214,11 @@ fn functions_and_inverses_tests() -> Result<()> {
 
         //("fraction", "fraction x over y end fraction"),
         ("mixed-fraction", "x i y"),
-        ("quotient", "podzielone przez z x przecinek, y"),
+        // Separator dwuargumentowy z IntentMappings ("| podzielone przez"):
+        // nazwa funkcji wraca na swoje miejsce, a spoiwo łączy oba argumenty.
+        ("quotient", "część całkowita z x podzielone przez y"),
         ("evaluated-at", "x obliczone w y"),
-        ("remainder", "podzielone przez z x przecinek, y"),
+        ("remainder", "reszta z x podzielone przez y"),
 
         ("max", "maksimum z x przecinek, y przecinek, z"),
         ("min", "minimum z x przecinek, y przecinek, z"),
@@ -228,10 +239,18 @@ fn functions_and_inverses_tests() -> Result<()> {
         ("real-part", "część rzeczywista"),
         ("imaginary-part", "część urojona"),
 
-        ("polar-coordinate", "przecinek z x przecinek, y"),
-        ("spherical-coordinate", "przecinek z x przecinek, y przecinek, z"),
-        ("cartesian-coordinate", "przecinek z x przecinek, y przecinek, z"),
-        ("coordinate", "przecinek, x przecinek y przecinek z"),
+        // Współrzędne: po usunięciu zbędnego "; przecinek" z IntentMappings
+        // nazwa wraca na swoje miejsce (wcześniej wyjście brzmiało "przecinek z x...").
+        ("polar-coordinate", "współrzędna biegunowa z x przecinek, y"),
+        (
+            "spherical-coordinate",
+            "współrzędna sferyczna z x przecinek, y przecinek, z",
+        ),
+        (
+            "cartesian-coordinate",
+            "współrzędna kartezjańska z x przecinek, y przecinek, z",
+        ),
+        ("coordinate", "współrzędna z x przecinek, y przecinek, z"),
 
         ("floor", "podłoga z x"),
         ("ceiling", "sufit z x"),
@@ -598,6 +617,11 @@ fn linear_algebra_tests() -> Result<()> {
               </math>"
               .to_string()
           }
+          "transpose" => "<math>
+                  <mrow intent='transpose:function($x)'>
+                      <mi arg='x'>x</mi>
+                  </mrow>
+              </math>".to_string(),
           _ => format!(
               "<math>
                   <mrow intent='{intent}($x)'>

--- a/tests/Languages/pl/mtable.rs
+++ b/tests/Languages/pl/mtable.rs
@@ -265,8 +265,8 @@ fn augmented_matrix_2x3() -> Result<()> {
       <mo>]</mo></mrow></mrow>
     </math>
                                 ";
-    test("pl", "ClearSpeak",  expr, "2 na 3 macierz rozszerzona; wiersz 1; 3, 1, 4; wiersz 2; 0, 2, 6")?;
-    test("pl", "SimpleSpeak", expr, "2 na 3 macierz rozszerzona; wiersz 1; 3, 1, 4; wiersz 2; 0, 2, 6")?;
+    test("pl", "ClearSpeak",  expr, "2 na 3 macierz rozszerzona; wiersz 1; 3, 1, separator, 4; wiersz 2; 0, 2, separator, 6")?;
+    test("pl", "SimpleSpeak", expr, "2 na 3 macierz rozszerzona; wiersz 1; 3, 1, separator, 4; wiersz 2; 0, 2, separator, 6")?;
     Ok(())
 }
 
@@ -897,9 +897,9 @@ let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
   </mrow>
 </math>";
 test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndMatrix",
-        expr, "3 na 4 macierz rozszerzona; wiersz 1; kolumna 1; 1, kolumna 2; 2, kolumna 3; minus 1, kolumna 4; 3; wiersz 2; kolumna 1; minus 3, kolumna 2; 3, kolumna 3; minus 1, kolumna 4; 2; wiersz 3; kolumna 1; 2, kolumna 2; 3, kolumna 3; 2, kolumna 4; minus 1; koniec macierzy")?;
+        expr, "3 na 4 macierz rozszerzona; wiersz 1; kolumna 1; 1, kolumna 2; 2, kolumna 3; minus 1, separator, kolumna 4; 3; wiersz 2; kolumna 1; minus 3, kolumna 2; 3, kolumna 3; minus 1, separator, kolumna 4; 2; wiersz 3; kolumna 1; 2, kolumna 2; 3, kolumna 3; 2, separator, kolumna 4; minus 1; koniec macierzy")?;
     test("pl", "SimpleSpeak",
-        expr, "3 na 4 macierz rozszerzona; wiersz 1; kolumna 1; 1, kolumna 2; 2, kolumna 3; minus 1, kolumna 4; 3; wiersz 2; kolumna 1; minus 3, kolumna 2; 3, kolumna 3; minus 1, kolumna 4; 2; wiersz 3; kolumna 1; 2, kolumna 2; 3, kolumna 3; 2, kolumna 4; minus 1; koniec macierzy")?;
+        expr, "3 na 4 macierz rozszerzona; wiersz 1; kolumna 1; 1, kolumna 2; 2, kolumna 3; minus 1, separator, kolumna 4; 3; wiersz 2; kolumna 1; minus 3, kolumna 2; 3, kolumna 3; minus 1, separator, kolumna 4; 2; wiersz 3; kolumna 1; 2, kolumna 2; 3, kolumna 3; 2, separator, kolumna 4; minus 1; koniec macierzy")?;
     Ok(())
   }
 
@@ -1294,3 +1294,42 @@ fn single_line_with_label() -> Result<()> {
       expr, "1 równanie, z etykietą 2; b równa się 2")?;
     return Ok(());
   }
+
+/// Linia pionowa w tabeli jest zapowiadana jako separator (upstream #679).
+#[test]
+fn dashed_augmented_matrix_separator() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow><mo>[</mo>
+        <mtable columnlines='dashed'>
+          <mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd><mtd><mn>3</mn></mtd></mtr>
+        </mtable>
+      <mo>]</mo></mrow>
+    </math>";
+    test("pl", "ClearSpeak", expr, "jeden na 3 wiersz macierz; 1, separator, 2, separator, 3")?;
+    test("pl", "SimpleSpeak", expr, "jeden na 3 wiersz macierz; 1, separator, 2, separator, 3")?;
+    Ok(())
+}
+
+/// Linia pozioma wybrzmiewa RAZ, po wierszu, ktory oddziela od nastepnego.
+#[test]
+fn matrix_row_separator() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow><mo>[</mo>
+        <mtable rowlines='solid'>
+          <mtr>
+            <mtd><mn>1</mn></mtd>
+            <mtd><mn>2</mn></mtd>
+          </mtr>
+          <mtr>
+            <mtd><mn>3</mn></mtd>
+            <mtd><mn>4</mn></mtd>
+          </mtr>
+        </mtable>
+      <mo>]</mo></mrow>
+    </math>";
+    test("pl", "ClearSpeak", expr, "2 na 2 macierz; wiersz 1; 1, 2, separator wiersza; wiersz 2; 3, 4")?;
+    test("pl", "SimpleSpeak", expr, "2 na 2 macierz; wiersz 1; 1, 2, separator wiersza; wiersz 2; 3, 4")?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Five independent fixes to the Polish localization. Three catch up with recent
changes to the English rule files; two fix defects that predate them.

Each commit is self-contained and can be reviewed on its own.

### 1. Up tack spoken as perpendicular (`6d0aaed9`)

Follow-up to 45aefb2d. Editors commonly emit U+22A5 where perpendicularity is
meant, so both U+27C2 and U+22A5 now say "jest prostopadle do", while
LiteralSpeak keeps reading U+22A5 literally. Previously Polish said "dol" for
U+22A5, so the same formula was read differently in Polish than in English.

### 2. The `|` argument-glue syntax (`92cfaf9b`)

Follow-up to 4347d884. Several intents lost their function name in speech:

| intent | before | after |
|---|---|---|
| `quotient` | podzielone przez z x przecinek, y | czesc calkowita z x podzielone przez y |
| `remainder` | podzielone przez z x przecinek, y | reszta z x podzielone przez y |
| `set-difference` | i z wielka a przecinek, wielka b | roznica zbiorow z wielka a i wielka b |
| `polar-coordinate` | przecinek z x przecinek, y | wspolrzedna biegunowa z x przecinek, y |

Adopting the syntax in `definitions.yaml` alone was not enough: the
`function-intent` rule has to call `IntentFunctionUseArityPath` /
`IntentFunctionGlueBefore`, which only `en` and `hu` did. That rule is now
ported to `pl`.

Also fixes `SharedRules/geometry.yaml`, where the `coordinate` rule matched `"."`
instead of `not(*[@arg])` and so swallowed `coordinate($x,...)` intents that
should fall through to IntentMappings; its name was mistranslated as "przecinek"
(comma) rather than "punkt" (point). Adds the missing `empty-set`, and orders
`transpose` fixities as `en` does.

**Not adopted:** arity templates (`| po | od,do`) for `sum`/`product` — see the
issue linked below.

### 3. Navigation direction words (`1fe33293`)

This is the most user-visible one, and it is not just a port.

`navigate.yaml` compared the suffix of `$NavCommand` — always English, e.g.
`ZoomIn` — against a substring offset by the length of the **spoken** `$Prefix`.
For English those lengths coincide; for any translation they do not:

```
ZoomIn        -> ""          (want "In")     "przybliz" is 8 chars, "Zoom" is 4
ZoomOutAll    -> "ll"        (want "OutAll")
MoveNext      -> "t"         (want "Next")
DescribeNext  -> "ibeNext"   (want "Next")
```

All 16 branches were dead, so users heard "przejdz; do mianownika" with no
direction, never "przejdz w prawo". `$CommandOffset`, introduced in ec36e057,
fixes all of them.

Polish also needs two verbs where English reuses "zoom": "przybliz na zewnatrz"
(zoom in outwards) is self-contradictory, so `ZoomOut*` now says "oddal" and the
direction word is dropped for plain In/Out, as the verb already carries it.

Ports `into-or-out-of-prefix-or-silent-without-parts` (080ca162) and the
`SpeakIntentName` fallbacks, keeping the Polish preposition logic.

### 4. Table column and row separators (`3cf59ebc`)

Follow-up to fbc49bb7. The `HasVisibleColumnLine` / `HasVisibleRowLine` rules
were missing from `pl`, so visible lines were silent and an augmented matrix was
read exactly like a plain one. Two existing Polish tests were pinning the
pre-#679 output; their English counterparts already expect "separator", so they
are updated rather than worked around.

### 5. Remaining untranslated unicode entries (`3ca7fac5`)

The audit tool reported 81 unicode entries whose text equals the English source.
Reviewing them one by one, only two were actually untranslated: U+2127
`mhos` -> `mho` (as `nb` and `sv` have it) and U+2644 Saturn, whose Polish
spelling is the same. The other 79 are correct as-is and only needed the
verified key: 30 Roman numerals spelled out letter by letter, 29 space/PUA/
zero-width entries with no speech, 6 typographic ligatures, and proper names
such as spesmilos, paragraphos and digamma.

Audit's "untranslated" count for the unicode files: 81 -> 0.

## Test plan

```
cargo test --test languages Languages::pl     607 -> 609 passed, 0 failed
cargo test --lib                              320 passed, 0 failed
cargo test --test languages (all languages)  4946 passed, 0 failed
uv run --project PythonScripts audit-translations pl
```

Adds four tests: `up_tack_330`, `zoom_speech_pl`, `move_char_speech_pl`,
`dashed_augmented_matrix_separator`, `matrix_row_separator`.

Each new test was checked for discrimination by reverting the corresponding fix:
with the old offset formula both navigation tests fail showing the missing
direction word, and removing either separator rule fails all four matrix tests.

`src/navigate.rs` gains only test code; no engine logic is touched.
