### PR TITLE
ja: read nPk permutations with the school phrase, in display order

### DIFF
--- a/Rules/Languages/ja/SharedRules/general.yaml
+++ b/Rules/Languages/ja/SharedRules/general.yaml
@@ -105,14 +105,16 @@
   - t: "同じ式が評価されるマイナス"      # phrase(this result is 'minus the same expression evaluated at' an earlier point)
   - x: "*[2]"
 
-- name: permutation
-  # Not a default because the order of the args is reversed
+- name: permutation   # audit-ignore
+  # en reverses the args ("k permutations of n"); Japanese reads nPk in display
+  # order with the standard school phrase: 5P2 = "5 個から 2 個取る順列"
   tag: pochhammer
   match: "count(*)=2 and contains(@data-intent-property, ':infix:')"
   replace:
-  - x: "*[2]"
-  - t: "順列の"      # phrase(the solution  involves several 'permutations of' values)
   - x: "*[1]"
+  - T: "個から"      # phrase(the solution  involves several 'permutations of' values)
+  - x: "*[2]"
+  - T: "個取る順列"
 
 - name: intervals
   tag: [open-interval, open-closed-interval, closed-interval, closed-open-interval]

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -629,3 +629,15 @@ fn divides_and_similar() -> Result<()> {
     }
     return Ok(());
 }
+
+/// nPk permutation notation is read with the standard Japanese school phrase
+/// and in display order: (superscript 5) P (subscript 2) is
+/// "5 個から 2 個取る順列" ("permutations taking 2 out of 5").
+/// en reverses the arguments ("2 permutations of 5"); Japanese does not need to.
+#[test]
+fn permutation_p_notation() -> Result<()> {
+    let expr = "<math><msubsup><mi>P</mi><mn>2</mn><mn>5</mn></msubsup></math>";
+    test("ja", "ClearSpeak", expr, "5 個から 2 個取る順列")?;
+    test("ja", "SimpleSpeak", expr, "5 個から 2 個取る順列")?;
+    return Ok(());
+}


### PR DESCRIPTION
This is the item #731's description left alone on purpose: 順列の, where "the right Japanese wording is a decision rather than a swap".

The pochhammer speech rule (reached from the nPk P-notation intents in `Rules/Intent/general.yaml`, whose children are [n, k]) copied the en argument reversal and glued 順列の between the arguments, so ⁵P₂ was spoken as 2 順列の 5 — word salad in Japanese. en says "2 permutations of 5" after Wikipedia's "k-permutations of n"; nb and sv rebuilt the phrase entirely ("antalet permutationer av 2 element ur 5"). Japanese has a standard school phrase that reads the notation in display order, so the reversal is simply not needed: **5 個から 2 個取る順列** ("permutations taking 2 out of 5").

The rule is marked `audit-ignore` the way nb's is, since the x:/T: sequence no longer mirrors en. A speech test covers the msubsup form in both ClearSpeak and SimpleSpeak — the first test added to `tests/Languages/ja/ja.rs` since the seed. The two `:infix:` guards and the match are kept identical to en, so nothing else that maps to pochhammer is affected.

`audit-translations ja`: untranslated text 3674 → 3673, rule differences 28 → 28, missing/extra rules 0 → 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


