### PR TITLE
Fix Japanese vocabulary in SharedRules (general.yaml, default.yaml)

### DIFF
--- a/Rules/Languages/ja/SharedRules/default.yaml
+++ b/Rules/Languages/ja/SharedRules/default.yaml
@@ -112,7 +112,7 @@
   - pause: short
   - test:
       if: "$Impairment = 'Blindness'"
-      then: [t: "リリース"]          # phrase("start of fraction x over y 'end over'")
+      then: [T: "分数終了"]          # phrase("start of fraction x over y 'end over'")
   - pause: medium
 
 
@@ -167,7 +167,7 @@
   match: "count(*)=2 and *[2][self::m:mrow and *[2][.='⁣']]"
   replace:
   - x: "*[1]"
-  - t: "サブサブ"               # phrase(x 'sub' 2)
+  - T: "下付き"               # phrase(x 'sub' 2)
   - x: "*[2]"
   - pause: short
 
@@ -176,7 +176,7 @@
   match: "."
   replace:
   - x: "*[1]"
-  - t: "サブサブ"               # phrase(x 'sub' 2)
+  - T: "下付き"               # phrase(x 'sub' 2)
   - x: "*[2]"
   - pause: short
 
@@ -189,7 +189,7 @@
   - x: "*[1]"
   - test:
       if: "not($Verbosity='Terse' and *[2][self::m:mn and not(translate(., '.,', '')!=.)])"  # just say "x 1" for terse vs "x sub 1"
-      then: [t: "サブサブ"]      # phrase(x 'sub' 2)
+      then: [T: "下付き"]      # phrase(x 'sub' 2)
   - x: "*[2]"
 
 
@@ -201,7 +201,7 @@
   - test:
       if: "name(.)='msubsup'"
       then:
-      - t: "サブサブ"          # phrase(x 'sub' 2)
+      - T: "下付き"          # phrase(x 'sub' 2)
       - x: "*[2]"
   - test:
       if: "*[last()][translate(., '′″‴⁗†‡°*', '')='']"
@@ -209,21 +209,21 @@
       else_test:
           if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"  # FIX: is this test necessary?
           then:
-          - t: "スーパー"      # phrase(x 'super' 2)
+          - T: "上付き"      # phrase(x 'super' 2)
           - x: "*[last()]"
           - test:
               if: "not(IsNode(*[last()], 'simple')) or $Impairment = 'Blindness'"
-              then: [t: "エンドスーパー"]      # phrase(x super 2 'end of super')
+              then: [T: "上付き終了"]      # phrase(x super 2 'end of super')
           else:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "上付き文字"]
-              else: [t: "スーパー"]
+              then: [T: "上付き文字"]
+              else: [T: "上付き"]
           - x: "*[last()]"
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "終了スーパースクリプト"]
-              else: [t: "エンドスーパー"]
+              then: [T: "上付き文字終了"]
+              else: [T: "上付き終了"]
 
 - name: default
   tag: munder

--- a/Rules/Languages/ja/SharedRules/general.yaml
+++ b/Rules/Languages/ja/SharedRules/general.yaml
@@ -37,15 +37,15 @@
   - bookmark: "*[1]/@id"
   - test:
     - if: "*[1][.='ℂ']"
-      then: [t: "シー"]      # phrase(the letter 'C' used to represent complex number)
+      then: [T: "シー"]      # phrase(the letter 'C' used to represent complex number)
     - else_if: "*[1][.='ℕ']"
-      then: [t: "ネクタイ"]      # phrase(the letter 'N' may represent natural numbers)
+      then: [T: "エヌ"]      # phrase(the letter 'N' may represent natural numbers)
     - else_if: "*[1][.='ℚ']"
-      then: [t: "キュー"]      # phrase(the letter 'Q' may represent rational numbers)
+      then: [T: "キュー"]      # phrase(the letter 'Q' may represent rational numbers)
     - else_if: "*[1][.='ℝ']"
-      then: [t: "アール"]      # phrase(the letter 'R' may represent real numbers)
+      then: [T: "アール"]      # phrase(the letter 'R' may represent real numbers)
     - else_if: "*[1][.='ℤ']"
-      then: [t: "ゼット"]      # phrase(the letter 'Z' may represent integers)
+      then: [T: "ゼット"]      # phrase(the letter 'Z' may represent integers)
       else: [x: "*[1][text()]"] # shouldn't happen
   - bookmark: "*[2]/@id"
   - x: "*[2]"
@@ -208,16 +208,16 @@
   - x: "*[1]"
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "下付き文字"]      # phrase(a 'subscript' may be used to indicate an index)
-      else: [t: "サブサブ"]      # phrase(the result is 'sub' optimal)
+      then: [T: "下付き文字"]      # phrase(a 'subscript' may be used to indicate an index)
+      else: [T: "下付き"]      # phrase(the result is 'sub' optimal)
   - x: "*[2]"
   - test:
       if: "not(IsNode(*[2],'leaf') and $Impairment = 'Blindness')"
       then:
       - test:
           if: "$Verbosity='Verbose'"
-          then: [t: "終了サブスクリプト"]      # phrase(this is the 'end subscript' position)
-          else: [t: "エンドサブ"]      # phrase(this is the 'end sub' position)
+          then: [T: "下付き文字終了"]      # phrase(this is the 'end subscript' position)
+          else: [T: "下付き終了"]      # phrase(this is the 'end sub' position)
       - pause: short
       else_test:
           if: "*[2][self::m:mi]"   # need a pause in "x sub k prime" so the prime is not associated with the 'k'
@@ -226,8 +226,8 @@
       if: "name(.)='say-super'"
       then_test:
         if: "$Verbosity='Verbose'"
-        then: [t: "上付き文字"]      # phrase(a 'superscript' number indicates raised to a power)
-        else: [t: "スーパー"]      # phrase(this is a 'super' set of numbers)
+        then: [T: "上付き文字"]      # phrase(a 'superscript' number indicates raised to a power)
+        else: [T: "上付き"]      # phrase(this is a 'super' set of numbers)
   - x: "*[3]"
   - pause: short
 
@@ -648,21 +648,21 @@
   replace:
   - t: ""      # phrase('the' 2 by 2 matrix M)
   - x: count(*)
-  - t: "1列ずつ"      # phrase(the 2 'by 1 column' matrix)
+  - T: "かける 1 列"      # phrase(the 2 'by 1 column' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "コンテンツ"]      # phrase(the 2 by 2 'vector')
-      else: [t: "行列"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "ベクトル"]      # phrase(the 2 by 2 'vector')
+      else: [T: "行列"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - x: "*/*"
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "リリース"      # phrase('end' of matrix)
+      - T: ""      # phrase('end' of matrix)
       - test:
           if: $ClearSpeak_Matrix = 'EndVector'
-          then: [t: "コンテンツ"]      # phrase(the 2 column 'vector')
-          else: [t: "行列"]      # phrase(the 2 by 2 'matrix')
+          then: [T: "ベクトル終了"]      # phrase(the 2 column 'vector')
+          else: [T: "行列終了"]      # phrase(the 2 by 2 'matrix')
 
 - name: default-column-matrix
   tag: matrix
@@ -671,16 +671,16 @@
   replace:
   - t: ""      # phrase('the' 2 by 2 matrix M)
   - x: "count(*)"
-  - t: "1列ずつ"      # phrase(the 2 'by 1 column' matrix)
+  - T: "かける 1 列"      # phrase(the 2 'by 1 column' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "コンテンツ"]      # phrase(the 2 column 'vector')
-      else: [t: "行列"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "ベクトル"]      # phrase(the 2 column 'vector')
+      else: [T: "行列"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - x: "*" # select the rows (mtr)
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "行列終了"]      # phrase(the 'end of matrix' has been reached)
+      then: [T: "行列終了"]      # phrase(the 'end of matrix' has been reached)
 
 - name: 1x2-or-3-matrix
   tag: matrix
@@ -696,18 +696,18 @@
   - t: "行"      # phrase(the 1 by 4 'row' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "コンテンツ"]      # phrase('the 1 by' 2 row 'vector')
-      else: [t: "行列"]      # phrase('the 1 by' 2 'matrix')
+      then: [T: "ベクトル"]      # phrase('the 1 by' 2 row 'vector')
+      else: [T: "行列"]      # phrase('the 1 by' 2 'matrix')
   - pause: long
   - x: "*/*"
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "リリース"      # phrase(the 'end' of matrix has been reached)
+      - T: ""      # phrase(the 'end' of matrix has been reached)
       - test:
           if: $ClearSpeak_Matrix = 'EndMatrix'
-          then: [t: "行列"]      # phrase(the 2 by 2 'matrix')
-          else: [t: "コンテンツ"]      # phrase(the 2 by 1 'vector')
+          then: [T: "行列終了"]      # phrase(the 2 by 2 'matrix')
+          else: [T: "ベクトル終了"]      # phrase(the 2 by 1 'vector')
 
 - name: default-row-matrix
   tag: matrix
@@ -719,19 +719,19 @@
   - t: "行"      # phrase(the 1 by 2 'row' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "コンテンツ"]      # phrase(the 2 by 1 'vector')
-      else: [t: "行列"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "ベクトル"]      # phrase(the 2 by 1 'vector')
+      else: [T: "行列"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - pause: medium
   - x: "*/*" # select the cols (mtd)
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "リリース"      # phrase(the 'end' of matrix has been reached)
+      - T: ""      # phrase(the 'end' of matrix has been reached)
       - test:
           if: $ClearSpeak_Matrix = 'EndMatrix'
-          then: [t: "行列"]      # phrase(the 2 by 2 'matrix')
-          else: [t: "コンテンツ"]      # phrase(the 2 by 1 'vector')
+          then: [T: "行列終了"]      # phrase(the 2 by 2 'matrix')
+          else: [T: "ベクトル終了"]      # phrase(the 2 by 1 'vector')
 
 - name: simple-small-matrix
   tag: [matrix, determinant]
@@ -758,11 +758,11 @@
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "リリース"      # phrase(the 'end' of matrix has been reached)
+      - T: ""      # phrase(the 'end' of matrix has been reached)
       - test:
           if: "self::m:determinant"
-          then: [t: "行列式"]      # phrase(the 2 by 2 'determinant')
-          else: [t: "行列"]      # phrase(the 2 by 2 'matrix')
+          then: [T: "行列式終了"]      # phrase(the 2 by 2 'determinant')
+          else: [T: "行列終了"]      # phrase(the 2 by 2 'matrix')
 
 - name: default-matrix
   tag: [matrix, determinant]
@@ -786,11 +786,11 @@
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "リリース"      # phrase(the 'end' of matrix has been reached)
+      - T: ""      # phrase(the 'end' of matrix has been reached)
       - test:
           if: "self::m:determinant"
-          then: [t: "行列式"]      # phrase(the 2 by 2 'determinant')
-          else: [t: "行列"]      # phrase(the 2 by 2 'matrix's)
+          then: [T: "行列式終了"]      # phrase(the 2 by 2 'determinant')
+          else: [T: "行列終了"]      # phrase(the 2 by 2 'matrix's)
 
 - name: chemistry-msub
   tag: [chemical-formula]
@@ -799,10 +799,10 @@
   - x: "*[2]"
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "下付き文字"]      # phrase(H 'subscript' 2)
+      then: [T: "下付き文字"]      # phrase(H 'subscript' 2)
       else_test:
         if: "$Verbosity='Medium'"
-        then: [t: "サブサブ"]      # phrase(H 'sub' 2)
+        then: [T: "下付き"]      # phrase(H 'sub' 2)
   - x: "*[3]"
 
 - name: dimension-by
@@ -820,10 +820,10 @@
   - x: "*[2]"
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "上付き文字"]      # phrase(H 'superscript' 2)
+      then: [T: "上付き文字"]      # phrase(H 'superscript' 2)
       else_test:
         if: "$Verbosity='Medium'"
-        then: [t: "スーパー"]      # phrase(H 'super' 2)
+        then: [T: "上付き"]      # phrase(H 'super' 2)
   - x: "*[3]"
   - test:
       if: "following-sibling::*[1][.='+' or .='-']" # a little lazy -- assumes chemistry superscripts end with + or -
@@ -851,10 +851,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "上付き文字"]      # phrase(H 'superscript' 2)
+              then: [T: "上付き文字"]      # phrase(H 'superscript' 2)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "スーパー"]      # phrase(H 'super' 2)
+                then: [T: "上付き"]      # phrase(H 'super' 2)
           - x: "$Prescripts[2]"
           - pause: "short"
       - test:
@@ -862,10 +862,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "下付き文字"]      # phrase(a 'subscript' may be used to indicate an index)
+              then: [T: "下付き文字"]      # phrase(a 'subscript' may be used to indicate an index)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "サブサブ"]      # phrase(here is a 'sub' total)
+                then: [T: "下付き"]      # phrase(here is a 'sub' total)
           - x: "$Prescripts[1]"
           - pause: "short"
       - test:
@@ -876,10 +876,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "上付き文字"]      # phrase(H 'superscript' 2)
+                  then: [T: "上付き文字"]      # phrase(H 'superscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "スーパー"]      # phrase(H 'super' 2)
+                    then: [T: "上付き"]      # phrase(H 'super' 2)
               - x: "$Prescripts[4]"
               - pause: "short"
           - test:
@@ -887,10 +887,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "下付き文字"]      # phrase(H 'subscript' 2)
+                  then: [T: "下付き文字"]      # phrase(H 'subscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "サブサブ"]      # phrase(H 'sub' 2)
+                    then: [T: "下付き"]      # phrase(H 'sub' 2)
               - x: "$Prescripts[3]"
               - pause: "short"
   - x: "*[1]" # base
@@ -902,10 +902,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "下付き文字"]      # phrase(phrase(H 'subscript' 2)
+              then: [T: "下付き文字"]      # phrase(phrase(H 'subscript' 2)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "サブサブ"]      # phrase(phrase(H 'sub' 2)
+                then: [T: "下付き"]      # phrase(phrase(H 'sub' 2)
           - x: "$Postscripts[1]"
           - pause: "short"
       - test:
@@ -913,10 +913,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "上付き文字"]      # phrase(H 'superscript' 2)
+              then: [T: "上付き文字"]      # phrase(H 'superscript' 2)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "スーパー"]          # phrase(H 'super' 2)
+                then: [T: "上付き"]          # phrase(H 'super' 2)
           - x: "$Postscripts[2]"
           - pause: "short"
       - test:
@@ -927,10 +927,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "下付き文字"]      # phrase(H 'subscript' 2)
+                  then: [T: "下付き文字"]      # phrase(H 'subscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "サブサブ"]          # phrase(H 'sub' 2)
+                    then: [T: "下付き"]          # phrase(H 'sub' 2)
               - x: "$Postscripts[3]"
               - pause: "short"
           - test:
@@ -938,10 +938,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "上付き文字"]      # phrase(H 'superscript' 2)
+                  then: [T: "上付き文字"]      # phrase(H 'superscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "スーパー"]          # phrase(H 'super' 2)
+                    then: [T: "上付き"]          # phrase(H 'super' 2)
               - x: "$Postscripts[4]"
               - pause: "short"
           - test:
@@ -952,10 +952,10 @@
                   then:
                   - test:
                       if: "$Verbosity='Verbose'"
-                      then: [t: "下付き文字"]    # phrase(H 'subscript' 2)
+                      then: [T: "下付き文字"]    # phrase(H 'subscript' 2)
                       else_test:
                         if: "$Verbosity='Medium'"
-                        then: [t: "サブサブ"]        # phrase(H 'sub' 2)
+                        then: [T: "下付き"]        # phrase(H 'sub' 2)
                   - x: "$Postscripts[5]"
                   - pause: "short"
               - test:
@@ -963,10 +963,10 @@
                   then:
                   - test:
                       if: "$Verbosity='Verbose'"
-                      then: [t: "上付き文字"]  # phrase(H 'superscript' 2)
+                      then: [T: "上付き文字"]  # phrase(H 'superscript' 2)
                       else_test:
                         if: "$Verbosity='Medium'"
-                        then: [t: "スーパー"]      # phrase(H 'super' 2)
+                        then: [T: "上付き"]      # phrase(H 'super' 2)
                   - x: "$Postscripts[6]"
                   - pause: "short"
               - test:
@@ -977,10 +977,10 @@
                       then:
                       - test:
                           if: "$Verbosity='Verbose'"
-                          then: [t: "下付き文字"]      # phrase(H 'subscript' 2)
+                          then: [T: "下付き文字"]      # phrase(H 'subscript' 2)
                           else_test:
                             if: "$Verbosity='Medium'"
-                            then: [t: "サブサブ"]      # phrase(H 'sub' 2)
+                            then: [T: "下付き"]      # phrase(H 'sub' 2)
                       - x: "$Postscripts[7]"
                       - pause: "short"
                   - test:
@@ -988,10 +988,10 @@
                       then:
                       - test:
                           if: "$Verbosity='Verbose'"
-                          then: [t: "上付き文字"]      # phrase(H 'superscript' 2)
+                          then: [T: "上付き文字"]      # phrase(H 'superscript' 2)
                           else_test:
                             if: "$Verbosity='Medium'"
-                            then: [t: "スーパー"]      # phrase(H 'super' 2)
+                            then: [T: "上付き"]      # phrase(H 'super' 2)
                       - x: "$Postscripts[8]"
                       - pause: "short"
       - test:
@@ -1019,12 +1019,12 @@
   - bookmark: "*[1]/@id"
   - test:
     - if: ".='s'"
-      then: [t: "固体"]      # phrase(Boron is a 'solid' in its natural state)
+      then: [T: "固体"]      # phrase(Boron is a 'solid' in its natural state)
     - else_if: ".='l'"
-      then: [t: "液体液体"]      # phrase(water is a 'liquid')
+      then: [T: "液体"]      # phrase(water is a 'liquid')
     - else_if: ".='g'"
-      then: [t: "ガスレンジ"]      # phrase(hydrogen is a 'gas' )
-      else: [t: "アキュース"]      # phrase(an 'aqueous' solution is contained in water)
+      then: [T: "気体"]      # phrase(hydrogen is a 'gas' )
+      else: [T: "水溶液"]      # phrase(an 'aqueous' solution is contained in water)
   - pause: short
 
 - name: chemical-formula-operator-bond
@@ -1035,13 +1035,13 @@
   - bookmark: "@id"
   - test:
     - if: ".='-' or .=':'"
-      then: [t: "シングルボンド"]      # phrase(a 'single bond' is formed when two atoms share one pair of electrons)
+      then: [T: "単結合"]      # phrase(a 'single bond' is formed when two atoms share one pair of electrons)
     - else_if: ".='=' or .='∷'"
-      then: [t: "ダブルボンド"]      # phrase(a 'double bond' may occur when two atoms share two pairs of electrons)
+      then: [T: "二重結合"]      # phrase(a 'double bond' may occur when two atoms share two pairs of electrons)
     - else_if: ".='≡'"
-      then: [t: "トリプルボンド"]      # phrase(a 'triple bond' occurs when two atoms share three pairs of electrons)
+      then: [T: "三重結合"]      # phrase(a 'triple bond' occurs when two atoms share three pairs of electrons)
     - else_if: ".='≣'"
-      then: [t: "四倍の結束"]      # phrase(a 'quadruple bond' occurs when two atoms share four pairs of electrons)
+      then: [T: "四重結合"]      # phrase(a 'quadruple bond' occurs when two atoms share four pairs of electrons)
       else: [x: "text()"]
 
 - name: chemical-formula-operator

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -672,3 +672,115 @@ fn menclose_line_on_left() -> Result<()> {
     test("ja", "ClearSpeak", expr, "左に 線, 囲み 2 分の 3 囲み終了")?;
     return Ok(());
 }
+
+/// The letter names in the dimension form of a number set (N squared) are the
+/// katakana letter names. ネクタイ is a necktie.
+#[test]
+fn number_set_dimension_letters() -> Result<()> {
+    for (letter, expected) in [
+        ("ℂ", "シー 2"),
+        ("ℕ", "エヌ 2"),
+        ("ℚ", "キュー 2"),
+        ("ℝ", "アール 2"),
+        ("ℤ", "ゼット 2"),
+    ] {
+        let expr = format!("<math><msup><mi>{letter}</mi><mn>2</mn></msup></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// A vector is ベクトル; コンテンツ is "content". The end marker is one word with
+/// the noun first, matching 行列終了 already used in the same file.
+#[test]
+fn column_vector_end_vector() -> Result<()> {
+    let expr = "<math display='block'>
+        <mrow><mo>(</mo><mrow><mtable>
+          <mtr><mtd><mn>1</mn></mtd></mtr>
+          <mtr><mtd><mn>2</mn></mtd></mtr>
+          <mtr><mtd><mn>3</mn></mtd></mtr>
+        </mtable></mrow><mo>)</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Matrix", "EndVector",
+        expr, "3 かける 1 列 ベクトル; 1; 2; 3; ベクトル終了")?;
+    return Ok(());
+}
+
+/// The row form, and the matrix form of the same end marker: 行列終了, not
+/// リリース 行列 ("release matrix").
+#[test]
+fn row_vector_and_matrix_end_markers() -> Result<()> {
+    let row = "<math display='block'>
+        <mrow><mo>[</mo><mrow><mtable>
+          <mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>
+        </mtable></mrow><mo>]</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Matrix", "EndVector",
+        row, "1 かける 2 行 ベクトル; 1, 2; ベクトル終了")?;
+    let square = "<math display='block'>
+        <mrow><mo>(</mo><mrow><mtable>
+          <mtr><mtd><mn>2</mn></mtd><mtd><mn>1</mn></mtd></mtr>
+          <mtr><mtd><mn>7</mn></mtd><mtd><mn>5</mn></mtd></mtr>
+        </mtable></mrow><mo>)</mo></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Matrix", "EndMatrix",
+        square, "2 かける 2 行列; 行 1; 2, 1; 行 2; 7, 5; 行列終了")?;
+    return Ok(());
+}
+
+/// Chemical states use the terms taught in Japanese chemistry: 固体 液体 気体
+/// 水溶液. ガスレンジ is a gas cooker and アキュース is not a word.
+#[test]
+fn chemical_states() -> Result<()> {
+    for (state, expected) in [
+        ("s", "大文字 n エー; 固体"),
+        ("l", "大文字 n エー; 液体"),
+        ("g", "大文字 n エー; 気体"),
+        ("aq", "大文字 n エー; 水溶液"),
+    ] {
+        let expr = format!(
+            "<math><mrow><mi>Na</mi><mrow><mo>(</mo><mrow><mi>{state}</mi></mrow><mo>)</mo></mrow></mrow></math>"
+        );
+        test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Terse")], &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// Bond names are 単結合 二重結合 三重結合 四重結合, not transliterations;
+/// 四倍の結束 is "quadruple solidarity", not a chemistry term.
+#[test]
+fn chemical_bonds() -> Result<()> {
+    let ethylene = "<math><mrow>
+          <msub><mi>H</mi><mn>2</mn></msub><mi>C</mi>
+          <mo>=</mo>
+          <mi>C</mi><msub><mi>H</mi><mn>2</mn></msub>
+      </mrow></math>";
+    test_prefs("ja", "SimpleSpeak", vec![("Verbosity", "Terse")], ethylene,
+        "大文字 h, 2 大文字 c, 二重結合 大文字 c, 大文字 h, 2")?;
+    return Ok(());
+}
+
+/// The short readings of sub and superscript are 下付き and 上付き, the same
+/// stems as the verbose 下付き文字 / 上付き文字 in the branch beside them.
+/// サブサブ is the word "sub" doubled and スーパー is a supermarket.
+#[test]
+fn sub_and_superscript_medium() -> Result<()> {
+    let sulfate = "<math><mrow><msup>
+          <mrow><mo>[</mo><mi>S</mi><msub><mi>O</mi><mn>4</mn></msub><mo>]</mo></mrow>
+          <mrow><mn>2</mn><mo>&#x2212;</mo></mrow>
+      </msup></mrow></math>";
+    test_prefs("ja", "ClearSpeak", vec![("Verbosity", "Medium")], sulfate,
+        "角括弧, 大文字 s, 大文字 o, 下付き 4; 角括弧閉じ 上付き 2 マイナス")?;
+    return Ok(());
+}
+
+/// A determinant ends with 行列式終了, built the same way as 行列終了.
+#[test]
+fn determinant_end_marker() -> Result<()> {
+    let expr = "<math><mrow><mrow><mo>|</mo>
+        <mtable>
+          <mtr><mtd><mn>2</mn></mtd><mtd><mn>1</mn></mtd></mtr>
+          <mtr><mtd><mn>7</mn></mtd><mtd><mn>5</mn></mtd></mtr>
+        </mtable>
+      <mo>|</mo></mrow></mrow></math>";
+    test_ClearSpeak("ja", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "2 かける 2 行列式; 行 1; 2, 1; 行 2; 7, 5; 行列式終了")?;
+    return Ok(());
+}


### PR DESCRIPTION
Continues the Japanese rule clean-up. This one is the shared rules, so every
one of these words is spoken by both ClearSpeak and SimpleSpeak.

### `SharedRules/general.yaml`

| English | ja before | reads as | now |
|---|---|---|---|
| `vector` (7 places) | コンテンツ | "content" | ベクトル |
| `end` of matrix/vector/determinant (5) | リリース | "release" | 行列終了 / ベクトル終了 / 行列式終了 |
| `by 1 column` (2) | 1列ずつ | "one column at a time" | かける 1 列 |
| `N`, the letter in ℕ² | ネクタイ | "necktie" | エヌ |
| `liquid` / `gas` / `aqueous` | 液体液体 / ガスレンジ / アキュース | doubled / "gas cooker" / not a word | 液体 / 気体 / 水溶液 |
| `quadruple bond` | 四倍の結束 | "quadruple solidarity" | 四重結合 |

`definitions.yaml` already reads `vector` as ベクトル and ℕ as エヌ, and the
`matrix` branch beside the vector one was already 行列, so these were single
branches left behind.

For `end`, the file already had 行列終了 for the combined "end matrix"
(line 683), so the noun branches now carry the whole phrase and the separate
`end` token is emptied — the same shape the file already uses for the English
article ("the" → `t: ""`).

The three sibling bonds were transliterations (シングルボンド / ダブルボンド /
トリプルボンド), so all four now use the terms taught in Japanese chemistry:
単結合 / 二重結合 / 三重結合 / 四重結合.

### Both files

`sub` was サブサブ, the word "sub" doubled, and `super` was スーパー, which in
Japanese means a supermarket. The verbose branch beside each of them already
said 下付き文字 / 上付き文字, so the short branches are now 下付き / 上付き.

Their end markers were either English word order or transliterations
(終了サブスクリプト, エンドサブ, エンドスーパー, 終了スーパースクリプト).
Japanese puts the noun first, which `ClearSpeak_Rules.yaml` already does with
上付き終了 / 根号終了 / 分数終了, so they are now 下付き終了 / 下付き文字終了 /
上付き終了 / 上付き文字終了.

`default.yaml` also had `end` → リリース for the end of a fraction, which is
only spoken to blind readers; it is now 分数終了.

Every occurrence of each of these words in `Rules/Languages/ja/SharedRules/`
is fixed, so the two files agree with each other.

### Checks

- `audit-translations ja`: untranslated text 3577 → 3493. The drop is exactly
  84, the number of lines promoted from `t:` to `T:`; missing rules 0, extra
  rules 0, and rule differences unchanged at 28.
- Adds `ja` tests for the number-set letters, the vector / matrix /
  determinant end markers, the short sub and superscript readings, and the
  chemical states and bonds.

### One thing I did not change

In `default-column-matrix`, the opening branch says `vector` under
`ClearSpeak_Matrix = 'EndVector'` but the closing branch says `end matrix`
unconditionally (`general.yaml` line 683, `en` line 681). A one-column vector
with four or more rows therefore opens as a vector and closes as a matrix.
That is the same in English, so it looks like an en-side question rather than
a translation one and I left both alone — happy to follow up if you would
like it changed in `en` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
