### PR TITLE
Fix pica unit parsing in spacing width conversion

### DIFF
--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -1408,9 +1408,10 @@ pub struct FontSizeGuess;
 ///    ""
 // 		   returns original node match isn't found
 impl FontSizeGuess {
+    /// Returns an estimated width in em units, using an assumed 12-point font for conversions.
     pub fn em_from_value(value_with_unit: &str) -> f64 {
         // match one or more digits followed by a unit -- there are many more units, but they tend to be large and rarer(?)
-        static FONT_VALUE: LazyLock<Regex> = LazyLock::new(|| { Regex::new(r"(-?[0-9]*\.?[0-9]*)(px|cm|mm|Q|in|ppc|pt|ex|em|rem)").unwrap() });
+        static FONT_VALUE: LazyLock<Regex> = LazyLock::new(|| { Regex::new(r"(-?[0-9]*\.?[0-9]*)(px|cm|mm|Q|in|pc|pt|ex|em|rem)").unwrap() });
         let cap = FONT_VALUE.captures(value_with_unit);
         if let Some(cap) = cap {
             if cap.len() == 3 {
@@ -1782,6 +1783,16 @@ mod tests {
         crate::interface::set_preference("Language", "en")?;
         crate::definitions::read_definitions_file(true)?;
         return Ok( () );
+    }
+
+    // Pica widths must use the existing 12pt font estimate: 1pc, 12pt, and 1em are equivalent.
+    #[test]
+    fn font_size_guess_pica_widths() {
+        assert_eq!(FontSizeGuess::em_from_value("1pc"), 1.0);
+        assert_eq!(FontSizeGuess::em_from_value("0.5pc"), 0.5);
+        assert_eq!(FontSizeGuess::em_from_value("-1pc"), -1.0);
+        assert_eq!(FontSizeGuess::em_from_value("12pt"), 1.0);
+        assert_eq!(FontSizeGuess::em_from_value("1em"), 1.0);
     }
 
     #[test]


### PR DESCRIPTION
MathML space widths expressed in picas, such as `1pc`, were interpreted as zero because the unit regex recognized `ppc` while the conversion handled `pc`. Correct the regex so `1pc` converts to `1em` under the existing 12-point font estimate, and document the return units and font assumption.

Add a regression test covering whole, fractional, and negative pica widths, plus equivalent point and em values. Existing speech and braille expectations are unchanged.

Validation: `cargo test --offline --lib font_size_guess_pica_widths` passed; `git diff --check` passed.
