### PR TITLE
ja: read the remaining fractions denominator-first, and name the menclose marks

### DIFF
--- a/Rules/Languages/ja/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/ja/ClearSpeak_Rules.yaml
@@ -147,7 +147,7 @@
   # Japanese says the denominator first: 3/4 is "4 分の 3". There is no separate ordinal
   # form to build (unlike "three fourths"), so the pattern is uniform for any two numbers.
   - x: "*[2]"
-  - t: "分の"      # phrase(the fraction 3 'over' 4)
+  - T: "分の"      # phrase(the fraction 3 'over' 4)
   - x: "*[1]"
 
 - name: fraction-over-simple

--- a/Rules/Languages/ja/SharedRules/default.yaml
+++ b/Rules/Languages/ja/SharedRules/default.yaml
@@ -89,22 +89,23 @@
   - "(IsNode(*[1],'leaf') and IsNode(*[2],'leaf')) and"
   - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
   replace:
-  - x: "*[1]"
-  - t: "分の"               # phrase("the fraction x 'over' y")
+  # Japanese says the denominator first: x/y is "y 分の x". The other order says y/x.
   - x: "*[2]"
+  - T: "分の"               # phrase("the fraction x 'over' y")
+  - x: "*[1]"
   - pause: short
 
 - name: literal-default
   tag: mfrac
   match: "."
   replace:
-  - t: "スタート"              # phrase("'start'  fraction x over y end of fraction")
+  - T: "分数"              # phrase("'start'  fraction x over y end of fraction")
   - pause: short
   - x: "*[1]"
   - test:
       if: "not(IsNode(*[1],'leaf'))"
       then: [pause: short]
-  - t: "分の"               # phrase("the fraction x 'over' y")
+  - T: "オーバー"             # phrase("the fraction x 'over' y")
   - test:
       if: "not(IsNode(*[2],'leaf'))"
       then: [pause: short]
@@ -254,7 +255,7 @@
   - x: "*[1]"
   - t: "付き"         # phrase(x modified 'with' y above it)
   - x: "*[2]"
-  - t: "詳しくはこちら"        # phrase(x modified 'with' y above it)
+  - T: "上"        # phrase(x modified 'with' y above it)
 
 - name: default
   tag: munderover
@@ -268,7 +269,7 @@
   - x: "*[2]"
   - t: "下および"    # phrase(x modified with y 'below and' y above it)
   - x: "*[3]"
-  - t: "詳しくはこちら"        # phrase(x modified with y 'above' it)
+  - T: "上"        # phrase(x modified with y 'above' it)
 
 - name: default
   #   Here we support up to 2 prescripts and up to 4 postscripts -- that should cover all reasonable cases
@@ -514,13 +515,13 @@
   replace:
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' box ')]"
-      then: [t: "ボックス", pause: short]      # phrase(the 'box' around the expression)
+      then: [T: "四角", pause: short]      # phrase(the 'box' around the expression)
   - test:
       if: ".[contains(@notation,'roundedbox')]"
-      then: [t: "ラウンドボックス", pause: short]      # phrase(the 'round box' around the expression)
+      then: [T: "角丸の四角", pause: short]      # phrase(the 'round box' around the expression)
   - test:
       if: ".[contains(@notation,'circle')]"
-      then: [t: "サークル", pause: short]      # phrase(the 'circle' around the expression)
+      then: [T: "円", pause: short]      # phrase(the 'circle' around the expression)
   - test:
       if: ".[ contains(concat(' ', normalize-space(@notation), ' '), ' left ') or contains(concat(' ', normalize-space(@notation), ' '), ' right ') or contains(@notation,'top') or contains(@notation,'bottom') ]"
       then:
@@ -547,24 +548,24 @@
           else:
           - test:
               if: ".[contains(@notation,'updiagonalstrike')]"
-              then: [t: "対角形", pause: short]      # phrase(the line runs 'up diagonal')
+              then: [T: "右上がりの斜め", pause: short]      # phrase(the line runs 'up diagonal')
           - test:
               if: ".[contains(@notation,'downdiagonalstrike')]"
-              then: [t: "ダウンの対角", pause: short]      # phrase(the line runs 'down diagonal')
+              then: [T: "右下がりの斜め", pause: short]      # phrase(the line runs 'down diagonal')
       - test:
           if: ".[contains(@notation,'verticalstrike')]"
           then: [t: "垂直方向", pause: short]      # phrase(the line is  'vertical')
       - test:
           if: ".[contains(@notation,'horizontalstrike')]"
           then: [t: "水平方向", pause: short]      # phrase(the line is 'horizontal')
-      - t: "クロスアウト"      # phrase(please 'cross out' the incorrect answer)
+      - T: "取り消し線"      # phrase(please 'cross out' the incorrect answer)
       - pause: short
   - test:
       if: ".[contains(@notation,'uparrow')]"
-      then: [t: "上下矢印", pause: short]      # phrase(direction is shown by the 'up arrow')
+      then: [T: "上矢印", pause: short]      # phrase(direction is shown by the 'up arrow')
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' downarrow ')]"
-      then: [t: "ダウン矢印", pause: short]      # phrase(the trend is shown by the 'down arrow')
+      then: [T: "下矢印", pause: short]      # phrase(the trend is shown by the 'down arrow')
   - test:
       if: ".[contains(@notation,'leftarrow')]"
       then: [t: "左矢印", pause: short]      # phrase(the 'left arrow' indicates going back)
@@ -585,28 +586,28 @@
       then: [t: "北西矢印", pause: short]      # phrase(direction is shown by the 'northwest arrow')
   - test:
       if: ".[contains(@notation,'updownarrow')]"
-      then: [t: "ダブルエンド垂直矢印", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
+      then: [T: "両向き垂直矢印", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
   - test:
       if: ".[contains(@notation,'leftrightarrow')]"
-      then: [t: "ダブルエンド水平矢印", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
+      then: [T: "両向き水平矢印", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
   - test:
       if: ".[contains(@notation,'northeastsouthwestarrow')]"
-      then: [t: "ダブルは対角矢印を終了", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
+      then: [T: "両向き右上がり矢印", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
   - test:
       if: ".[contains(@notation,'northwestsoutheastarrow')]"
-      then: [t: "二重は対角矢印を終了", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
+      then: [T: "両向き右下がり矢印", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
   - test:
       if: ".[contains(@notation,'actuarial')]"
-      then: [t: "行動シンボル", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)
+      then: [T: "保険数理記号", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)
   - test:
       if: ".[contains(@notation,'madrub')]"
-      then: [t: "アラビア語の要素のシンボル", pause: short]      # phrase(the 'arabic factorial symbol' represents a factorial operation)
+      then: [T: "アラビア文字の階乗記号", pause: short]      # phrase(the 'arabic factorial symbol' represents a factorial operation)
   - test:
       if: ".[contains(@notation,'phasorangle')]"
       then: [t: "フェーザの角度", pause: short]      # phrase(the 'phasor angle' is used to measure electrical current)
   - test:
       if: ".[contains(@notation,'longdiv') or not(@notation) or normalize-space(@notation) ='']" # default
-      then: [t: "ロングディビジョンシンボル", pause: short]      # phrase(the 'long division symbol' indicates  a long division calculation)
+      then: [T: "割り算の筆算の記号", pause: short]      # phrase(the 'long division symbol' indicates  a long division calculation)
   - test:
       if: ".[contains(@notation,'radical')]"
       then: [t: "平方根", pause: short]      # phrase(5 is the 'square root' of 25)

--- a/Rules/Languages/ja/SharedRules/default.yaml
+++ b/Rules/Languages/ja/SharedRules/default.yaml
@@ -505,7 +505,7 @@
   tag: menclose
   match: "@notation='box' and *[self::m:mtext and .=' ']"
   replace:
-  - t: "空の箱"      # phrase(the 'empty box' contains no values)
+  - T: "空の四角"      # phrase(the 'empty box' contains no values)
 
 - name: default
   # The ordering below is the order in which words come out when there is more than one value
@@ -548,16 +548,16 @@
           else:
           - test:
               if: ".[contains(@notation,'updiagonalstrike')]"
-              then: [T: "右上がりの斜め", pause: short]      # phrase(the line runs 'up diagonal')
+              then: [T: "右上がり方向", pause: short]      # phrase(the line runs 'up diagonal')
           - test:
               if: ".[contains(@notation,'downdiagonalstrike')]"
-              then: [T: "右下がりの斜め", pause: short]      # phrase(the line runs 'down diagonal')
+              then: [T: "右下がり方向", pause: short]      # phrase(the line runs 'down diagonal')
       - test:
           if: ".[contains(@notation,'verticalstrike')]"
-          then: [t: "垂直方向", pause: short]      # phrase(the line is  'vertical')
+          then: [T: "垂直方向", pause: short]      # phrase(the line is  'vertical')
       - test:
           if: ".[contains(@notation,'horizontalstrike')]"
-          then: [t: "水平方向", pause: short]      # phrase(the line is 'horizontal')
+          then: [T: "水平方向", pause: short]      # phrase(the line is 'horizontal')
       - T: "取り消し線"      # phrase(please 'cross out' the incorrect answer)
       - pause: short
   - test:
@@ -586,16 +586,16 @@
       then: [t: "北西矢印", pause: short]      # phrase(direction is shown by the 'northwest arrow')
   - test:
       if: ".[contains(@notation,'updownarrow')]"
-      then: [T: "両向き垂直矢印", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
+      then: [T: "上下矢印", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
   - test:
       if: ".[contains(@notation,'leftrightarrow')]"
-      then: [T: "両向き水平矢印", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
+      then: [T: "左右矢印", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
   - test:
       if: ".[contains(@notation,'northeastsouthwestarrow')]"
-      then: [T: "両向き右上がり矢印", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
+      then: [T: "北東・南西矢印", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
   - test:
       if: ".[contains(@notation,'northwestsoutheastarrow')]"
-      then: [T: "両向き右下がり矢印", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
+      then: [T: "北西・南東矢印", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
   - test:
       if: ".[contains(@notation,'actuarial')]"
       then: [T: "保険数理記号", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)

--- a/Rules/Languages/ja/SharedRules/general.yaml
+++ b/Rules/Languages/ja/SharedRules/general.yaml
@@ -145,7 +145,7 @@
       if: "$Verbosity!='Terse'"
       then:
       - t: ""      # phrase('the' square root of 25 equals 5)
-  - t: "ポイント"      # phrase(a decimal 'point' indicates the fraction component of a number)
+  - T: "点"      # phrase(a decimal 'point' indicates the fraction component of a number)
   - x: "*[1]"
   - t: "コンマ"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
   - x: "*[2]"
@@ -581,7 +581,7 @@
       then: [t: "行列式"]      # phrase(the 2 by 2 'determinant'))
       else: [t: "行列"]      # phrase(the 2 by 2 'matrix')
       
-  - t: "エントリー"      # phrase(the 2 by 2 matrix 'with entry' x)
+  - T: "成分"      # phrase(the 2 by 2 matrix 'with entry' x)
   - x: "*[1]/*"
 
 # simpler reading methods for special case matrices

--- a/Rules/Languages/ja/SharedRules/linear-algebra.yaml
+++ b/Rules/Languages/ja/SharedRules/linear-algebra.yaml
@@ -28,7 +28,7 @@
       then:
       - t: ""      # phrase('the' square root of 25 equals 5)
   - x: "*[2]"
-  - t: "ノルダム"      # phrase(the 'norm' can be a measure of distance)
+  - T: "ノルム"      # phrase(the 'norm' can be a measure of distance)
   - test:
       if: "$Verbosity!='Terse'"
       then:

--- a/Rules/Languages/ja/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/ja/SimpleSpeak_Rules.yaml
@@ -83,7 +83,7 @@
   replace:
   # Japanese says the denominator first: 3/4 is "4 分の 3".
   - x: "*[2]"
-  - t: "分の"      # phrase(the fraction 3 'over' 4)
+  - T: "分の"      # phrase(the fraction 3 'over' 4)
   - x: "*[1]"
 
 - name: common-fraction-mixed-number
@@ -94,7 +94,7 @@
   - "*[2][self::m:mn][not(contains(., '.'))]"
   replace:
   - x: "*[2]"
-  - t: "分の"      # phrase(the fraction 3 'over' 4)
+  - T: "分の"      # phrase(the fraction 3 'over' 4)
   - x: "*[1]"
 
 

--- a/Rules/Languages/ja/overview.yaml
+++ b/Rules/Languages/ja/overview.yaml
@@ -20,9 +20,10 @@
   - test:
       if: "IsNode(*[1], 'simple') and IsNode(*[2], 'simple')"
       then:
-      - x: "*[1]"
-      - t: "分の"
+      # Japanese says the denominator first: x/y is "y 分の x". The other order says y/x.
       - x: "*[2]"
+      - T: "分の"
+      - x: "*[1]"
       else:
       - t: "分数"
 

--- a/Rules/Languages/ja/unicode.yaml
+++ b/Rules/Languages/ja/unicode.yaml
@@ -124,7 +124,7 @@
  - ".":                                          # 0x2e
     - test:
         if: "parent::*[1][self::m:mn]"
-        then: [t: "ポイント"]
+        then: [T: "点"]
         else: [t: "ドット"]
  - "/":                                           # 0x2f
     - test:

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -799,7 +799,7 @@ fn literal_speak_simple_fraction() -> Result<()> {
 #[test]
 fn literal_speak_bracketed_fraction() -> Result<()> {
     let expr = "<math><mfrac><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mn>2</mn></mfrac></math>";
-    test("ja", "LiteralSpeak", expr, "分数 x プラス 1 オーバー 2 分数終了")?;
+    test("ja", "LiteralSpeak", expr, "分数, x プラス 1, オーバー 2, 分数終了")?;
     return Ok(());
 }
 
@@ -822,8 +822,8 @@ fn overview_fraction_is_denominator_first() -> Result<()> {
 #[test]
 fn menclose_strikes() -> Result<()> {
     for (notation, expected) in [
-        ("updiagonalstrike", "右上がりの斜め 取り消し線, 囲み x 囲み終了"),
-        ("downdiagonalstrike", "右下がりの斜め 取り消し線, 囲み x 囲み終了"),
+        ("updiagonalstrike", "右上がりの斜め, 取り消し線, 囲み x 囲み終了"),
+        ("downdiagonalstrike", "右下がりの斜め, 取り消し線, 囲み x 囲み終了"),
     ] {
         let expr = format!("<math><menclose notation='{notation}'><mi>x</mi></menclose></math>");
         test("ja", "ClearSpeak", &expr, expected)?;
@@ -867,14 +867,14 @@ fn something_above_and_below_an_expression() -> Result<()> {
     let over = "<math><mover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>y</mi></mover></math>";
     test("ja", "ClearSpeak", over, "数量 x プラス 1 付き y 上")?;
     let both = "<math><munderover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>a</mi><mi>b</mi></munderover></math>";
-    test("ja", "ClearSpeak", both, "数量 x プラス 1 付き a 下および b 上")?;
+    test("ja", "ClearSpeak", both, "数量 x プラス 1 付き エー 下および b 上")?;
     return Ok(());
 }
 
 /// ノルダム is Notre-Dame. The Japanese for a norm is ノルム.
 #[test]
 fn subscripted_norm() -> Result<()> {
-    let expr = "<math><msub><mrow><mo>&#x2016;</mo><mi>x</mi><mo>&#x2016;</mo></mrow><mn>2</mn></msub></math>";
+    let expr = "<math><msub><mrow><mo>&#x2225;</mo><mi>x</mi><mo>&#x2225;</mo></mrow><mn>2</mn></msub></math>";
     test("ja", "ClearSpeak", expr, "2 ノルム の x")?;
     return Ok(());
 }

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -784,3 +784,105 @@ fn determinant_end_marker() -> Result<()> {
         expr, "2 かける 2 行列式; 行 1; 2, 1; 行 2; 7, 5; 行列式終了")?;
     return Ok(());
 }
+
+/// LiteralSpeak reads what is written, and Japanese writes the denominator
+/// first: 3/4 is "4 分の 3". "3 分の 4" is the other number, 4/3.
+#[test]
+fn literal_speak_simple_fraction() -> Result<()> {
+    let expr = "<math><mfrac><mn>3</mn><mn>4</mn></mfrac></math>";
+    test("ja", "LiteralSpeak", expr, "4 分の 3")?;
+    return Ok(());
+}
+
+/// A fraction that is not two leaves is bracketed instead, and then the written
+/// order is kept with the borrowed オーバー, as ClearSpeak already does.
+#[test]
+fn literal_speak_bracketed_fraction() -> Result<()> {
+    let expr = "<math><mfrac><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mn>2</mn></mfrac></math>";
+    test("ja", "LiteralSpeak", expr, "分数 x プラス 1 オーバー 2 分数終了")?;
+    return Ok(());
+}
+
+/// The overview rules (what the "describe" navigation command speaks) have their
+/// own fraction rule, and it has to say the denominator first as well.
+#[test]
+fn overview_fraction_is_denominator_first() -> Result<()> {
+    set_rules_dir(abs_rules_dir_path())?;
+    set_preference("Language", "ja")?;
+    set_preference("SpeechStyle", "SimpleSpeak")?;
+    set_preference("Verbosity", "Medium")?;
+    set_mathml("<math><mfrac><mn>3</mn><mn>4</mn></mfrac></math>")?;
+    let spoken = get_overview_text()?;
+    assert_eq!("4 分の 3", spoken.trim_end_matches([' ', ',', ';']));
+    return Ok(());
+}
+
+/// A strike names its direction and then the mark. 対角形 ("diagonal shape") does
+/// not say which diagonal, and クロスアウト is the English "cross out".
+#[test]
+fn menclose_strikes() -> Result<()> {
+    for (notation, expected) in [
+        ("updiagonalstrike", "右上がりの斜め 取り消し線, 囲み x 囲み終了"),
+        ("downdiagonalstrike", "右下がりの斜め 取り消し線, 囲み x 囲み終了"),
+    ] {
+        let expr = format!("<math><menclose notation='{notation}'><mi>x</mi></menclose></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// The shapes and the long division mark were transliterations of the English.
+#[test]
+fn menclose_shapes_and_long_division() -> Result<()> {
+    for (notation, expected) in [
+        ("circle", "円, 囲み x 囲み終了"),
+        ("roundedbox", "角丸の四角, 囲み x 囲み終了"),
+        ("longdiv", "割り算の筆算の記号, 囲み x 囲み終了"),
+    ] {
+        let expr = format!("<math><menclose notation='{notation}'><mi>x</mi></menclose></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// 上下矢印 is an arrow with a head at each end, so the single up arrow and the
+/// three double ended arrows all named the same thing.
+#[test]
+fn menclose_arrows() -> Result<()> {
+    for (notation, expected) in [
+        ("uparrow", "上矢印, 囲み x 囲み終了"),
+        ("updownarrow", "両向き垂直矢印, 囲み x 囲み終了"),
+        ("northeastsouthwestarrow", "両向き右上がり矢印, 囲み x 囲み終了"),
+    ] {
+        let expr = format!("<math><menclose notation='{notation}'><mi>x</mi></menclose></math>");
+        test("ja", "ClearSpeak", &expr, expected)?;
+    }
+    return Ok(());
+}
+
+/// 詳しくはこちら is the web phrase "click here for details". The word wanted here
+/// is "above", the partner of the 下 in the rule next to it.
+#[test]
+fn something_above_and_below_an_expression() -> Result<()> {
+    let over = "<math><mover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>y</mi></mover></math>";
+    test("ja", "ClearSpeak", over, "数量 x プラス 1 付き y 上")?;
+    let both = "<math><munderover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>a</mi><mi>b</mi></munderover></math>";
+    test("ja", "ClearSpeak", both, "数量 x プラス 1 付き a 下および b 上")?;
+    return Ok(());
+}
+
+/// ノルダム is Notre-Dame. The Japanese for a norm is ノルム.
+#[test]
+fn subscripted_norm() -> Result<()> {
+    let expr = "<math><msub><mrow><mo>&#x2016;</mo><mi>x</mi><mo>&#x2016;</mo></mrow><mn>2</mn></msub></math>";
+    test("ja", "ClearSpeak", expr, "2 ノルム の x")?;
+    return Ok(());
+}
+
+/// A matrix has 成分, not エントリー, and a coordinate is a 点, as in geometry.yaml.
+#[test]
+fn matrix_entry_and_point() -> Result<()> {
+    let matrix = "<math><mrow><mo>(</mo><mtable><mtr><mtd><mi>x</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>";
+    test("ja", "ClearSpeak", matrix, "1 かける 1 行列 成分 x")?;
+    return Ok(());
+}

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -888,12 +888,10 @@ fn matrix_entry() -> Result<()> {
     return Ok(());
 }
 
-/// A coordinate is a 点, the word geometry.yaml already uses, and the decimal
-/// point is 点 as well: 3.5 is "3 点 5".
+/// A coordinate is a 点, the word geometry.yaml already uses.
 #[test]
-fn point_and_decimal_point() -> Result<()> {
+fn coordinate_point() -> Result<()> {
     let coordinate = "<math><mrow intent='point($x,$y)'><mn arg='x'>1</mn><mo>,</mo><mn arg='y'>2</mn></mrow></math>";
     test("ja", "ClearSpeak", coordinate, "点 1 コンマ 2")?;
-    test("ja", "ClearSpeak", "<math><mn>3.5</mn></math>", "3 点 5")?;
     return Ok(());
 }

--- a/tests/Languages/ja/ja.rs
+++ b/tests/Languages/ja/ja.rs
@@ -822,8 +822,8 @@ fn overview_fraction_is_denominator_first() -> Result<()> {
 #[test]
 fn menclose_strikes() -> Result<()> {
     for (notation, expected) in [
-        ("updiagonalstrike", "右上がりの斜め, 取り消し線, 囲み x 囲み終了"),
-        ("downdiagonalstrike", "右下がりの斜め, 取り消し線, 囲み x 囲み終了"),
+        ("updiagonalstrike", "右上がり方向, 取り消し線, 囲み x 囲み終了"),
+        ("downdiagonalstrike", "右下がり方向, 取り消し線, 囲み x 囲み終了"),
     ] {
         let expr = format!("<math><menclose notation='{notation}'><mi>x</mi></menclose></math>");
         test("ja", "ClearSpeak", &expr, expected)?;
@@ -845,14 +845,15 @@ fn menclose_shapes_and_long_division() -> Result<()> {
     return Ok(());
 }
 
-/// 上下矢印 is an arrow with a head at each end, so the single up arrow and the
-/// three double ended arrows all named the same thing.
+/// 上下矢印 is an arrow with a head at each end, so it was the wrong name for the
+/// single up arrow. The double ended arrows had the English "double ended" in them;
+/// unicode-full.yaml already calls ↕ 上下矢印 and ⤢ 北東・南西矢印.
 #[test]
 fn menclose_arrows() -> Result<()> {
     for (notation, expected) in [
         ("uparrow", "上矢印, 囲み x 囲み終了"),
-        ("updownarrow", "両向き垂直矢印, 囲み x 囲み終了"),
-        ("northeastsouthwestarrow", "両向き右上がり矢印, 囲み x 囲み終了"),
+        ("updownarrow", "上下矢印, 囲み x 囲み終了"),
+        ("northeastsouthwestarrow", "北東・南西矢印, 囲み x 囲み終了"),
     ] {
         let expr = format!("<math><menclose notation='{notation}'><mi>x</mi></menclose></math>");
         test("ja", "ClearSpeak", &expr, expected)?;
@@ -864,10 +865,10 @@ fn menclose_arrows() -> Result<()> {
 /// is "above", the partner of the 下 in the rule next to it.
 #[test]
 fn something_above_and_below_an_expression() -> Result<()> {
-    let over = "<math><mover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>y</mi></mover></math>";
-    test("ja", "ClearSpeak", over, "数量 x プラス 1 付き y 上")?;
-    let both = "<math><munderover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>a</mi><mi>b</mi></munderover></math>";
-    test("ja", "ClearSpeak", both, "数量 x プラス 1 付き エー 下および b 上")?;
+    let over = "<math><mover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>z</mi></mover></math>";
+    test("ja", "ClearSpeak", over, "数量 x プラス 1 付き z 上")?;
+    let both = "<math><munderover><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mi>y</mi><mi>z</mi></munderover></math>";
+    test("ja", "ClearSpeak", both, "数量 x プラス 1 付き y 下および z 上")?;
     return Ok(());
 }
 
@@ -879,10 +880,20 @@ fn subscripted_norm() -> Result<()> {
     return Ok(());
 }
 
-/// A matrix has 成分, not エントリー, and a coordinate is a 点, as in geometry.yaml.
+/// A matrix has 成分, not エントリー.
 #[test]
-fn matrix_entry_and_point() -> Result<()> {
+fn matrix_entry() -> Result<()> {
     let matrix = "<math><mrow><mo>(</mo><mtable><mtr><mtd><mi>x</mi></mtd></mtr></mtable><mo>)</mo></mrow></math>";
     test("ja", "ClearSpeak", matrix, "1 かける 1 行列 成分 x")?;
+    return Ok(());
+}
+
+/// A coordinate is a 点, the word geometry.yaml already uses, and the decimal
+/// point is 点 as well: 3.5 is "3 点 5".
+#[test]
+fn point_and_decimal_point() -> Result<()> {
+    let coordinate = "<math><mrow intent='point($x,$y)'><mn arg='x'>1</mn><mo>,</mo><mn arg='y'>2</mn></mrow></math>";
+    test("ja", "ClearSpeak", coordinate, "点 1 コンマ 2")?;
+    test("ja", "ClearSpeak", "<math><mn>3.5</mn></math>", "3 点 5")?;
     return Ok(());
 }


### PR DESCRIPTION
Two groups of fixes in the shared `ja` rule files. Everything stays inside `Rules/Languages/ja/` and `tests/Languages/ja/`.

## 1. Three fraction rules read the fraction backwards

Japanese states the denominator first: 3/4 is "4 分の 3". Numerator-first does not just sound odd, it names a different number — "3 分の 4" is 4/3.

`common-fraction` in `ClearSpeak_Rules.yaml` and `SimpleSpeak_Rules.yaml` already swaps the operands, but three rules were still numerator-first:

- `SharedRules/default.yaml` `literal-simple` (tag `mfrac`, reached with `SpeechStyle=LiteralSpeak`, which is also what navigation falls back to in Character mode — `src/navigate.rs:588`)
- `overview.yaml` `overview-default` (what `DescribePrevious/Next/Current` speak)

Both now say the denominator first, with the same comment `common-fraction` carries.

- `SharedRules/default.yaml` `literal-default` has explicit start/end markers, so instead of swapping it keeps the written order and uses the borrowed オーバー — the form Yamaguchi, Kawane & Sawazaki (1996) give for a fraction that is not two plain numbers: 分数 A オーバー B 分数終了. It also opened with スタート, the English word "start".

Note on scope: `literal-simple` matches any two leaves, so it now says 分の for `x/y` as well as for `3/4`. The cited source reserves 分の for two numbers, but "b 分の a" is ordinary Japanese for a fraction of two symbols too, and this rule has no start/end markers to hang the オーバー form on.

## 2. Names that were still the machine translation

`SharedRules/default.yaml`, menclose:

| notation | was | now | why |
|---|---|---|---|
| `uparrow` | 上下矢印 | 上矢印 | 上下矢印 is an arrow with a head at *each* end |
| `downarrow` | ダウン矢印 | 下矢印 | half English |
| `updownarrow` | ダブルエンド垂直矢印 | 上下矢印 | the name `unicode-full.yaml:558` already gives ↕ |
| `leftrightarrow` | ダブルエンド水平矢印 | 左右矢印 | the name `unicode-full.yaml:557` already gives ↔ |
| `northeastsouthwestarrow` | ダブルは対角矢印を終了 | 北東・南西矢印 | "double is ends diagonal arrow" is not a sentence; the name is `unicode-full.yaml:1824` for ⤢ |
| `northwestsoutheastarrow` | 二重は対角矢印を終了 | 北西・南東矢印 | same, `unicode-full.yaml:1823` for ⤡ |
| `updiagonalstrike` | 対角形 | 右上がり方向 | "diagonal shape" does not say which diagonal; 方向 matches the 垂直方向 / 水平方向 beside it |
| `downdiagonalstrike` | ダウンの対角 | 右下がり方向 | half English |
| crossout | クロスアウト | 取り消し線 | |
| `box` / `roundedbox` / `circle` | ボックス / ラウンドボックス / サークル | 四角 / 角丸の四角 / 円 | |
| empty box | 空の箱 | 空の四角 | so that "box" is one word in this file |
| `actuarial` | 行動シンボル | 保険数理記号 | 行動シンボル is an "action symbol" |
| `madrub` | アラビア語の要素のシンボル | アラビア文字の階乗記号 | reads "Arabic-language element symbol"; madrub is the factorial symbol written in Arabic script |
| `longdiv` | ロングディビジョンシンボル | 割り算の筆算の記号 | |

Also in `SharedRules/default.yaml`, the `mover` and `munderover` rules said 詳しくはこちら for "above". That is the web phrase "click here for details"; the word wanted is 上, the partner of the 下 already in the rule beside it.

And three single words:

- `SharedRules/linear-algebra.yaml` — ノルダム is Notre-Dame. A norm is ノルム.
- `SharedRules/general.yaml` `1x1-matrix` — エントリー → 成分, the term for a matrix entry.
- `SharedRules/general.yaml` `default-point` and `unicode.yaml` `.` — ポイント → 点, which is what `geometry.yaml:71` already says for a coordinate and what a Japanese reader says for a decimal point.

## Checks

- `audit-translations ja`: Untranslated text 3493 → 3462. That is exactly −31, the number of lines promoted from `t:` to `T:` after checking each against the `en` line beside it. Missing rules 0, extra rules 0, and **Rule differences 28 → 28**, i.e. swapping the two operands did not make the rules diverge structurally from `en`.
- 10 tests added: both fraction paths, the overview path, the menclose strikes / shapes / long division / arrows, above and below, the norm, the matrix entry and the coordinate. Every expected string is the actual output.
- The `.` character rule in `unicode.yaml` is the one change with no test: I could not build MathML that reaches its `parent::*[1][self::m:mn]` branch — a plain `<mn>3.5</mn>` is spoken as one token.
- The `分の` lines in `ClearSpeak_Rules.yaml` and `SimpleSpeak_Rules.yaml` are promoted to `T:` as well, so the word is not verified in two files and unverified in two others.

## Left alone on purpose

- `unicode-full.yaml`, waiting for the MathPlayer seed.
- `navigate.yaml`, which #752 is already touching. I checked that the two branches merge cleanly in either order and give the same tree.
- `phasorangle` (フェーザの角度) and the single compass arrows (北東矢印 etc.) are literal but not wrong, so I left them.
- The relation symbols in `unicode.yaml` are inconsistent — `<` is 小なり but `>` is より大きい, and `∈` is 要素の where the source gives 要素オブ. That is a separate theme and will be a separate PR.
